### PR TITLE
Multi judges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,14 +27,17 @@ EVAL_LLM_PROVIDER=
 EVAL_LLM_PROVIDER_BASE_URL=
 EVAL_LLM_API_KEY=
 
-# JSON array of judge configs (minimum 2 entries). Each object:
-#   model            – model name (e.g. "gpt-4o", "sonnet-4")
-#   provider         – LangChain provider id (e.g. "openai", "anthropic")
-#   api_key_field    – name of a SecretStr field on Settings (e.g. "openai_api_key"), NOT the raw key
-#   base_url         – optional custom endpoint (leave "" for default)
+# Jury-of-judges evaluation (optional, minimum 2 entries)
+# When set, each evaluator runs through ALL judges.
+# Strategy: Minority Veto — score is PASS only if every judge passes.
 #
-# Example:
-# EVAL_JURY_JUDGES='[{"model":"gpt-4o","provider":"openai","api_key_field":"openai_api_key","base_url":""},{"model":"sonnet-4","provider":"anthropic","api_key_field":"anth_api_key","base_url":""}]'
+# Fields per judge:
+#   model          – model name (e.g. "gpt-4o", "claude-sonnet")
+#   provider       – LangChain provider id (e.g. "openai", "anthropic")
+#   api_key_field  – name of a SecretStr field on Settings (e.g. "openai_api_key")
+#   base_url       – custom endpoint, or "" for provider default
+#
+# EVAL_JURY_JUDGES='[{"model":"gpt-4o","provider":"openai","api_key_field":"openai_api_key","base_url":""},{"model":"claude-sonnet","provider":"anthropic","api_key_field":"anthropic_api_key","base_url":""}]'
 EVAL_JURY_JUDGES=
 
 # Langsmith Configuration for tracing (optional)

--- a/src/config.py
+++ b/src/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     eval_llm_provider: str = "openai"
     eval_llm_provider_base_url: str = "https://api.openai.com/v1"
     eval_llm_api_key: SecretStr | None = None
-    # cerebras_api_key: SecretStr | None = None
+    cerebras_api_key: SecretStr | None = None
 
     # Jury-of-judges configuration (optional JSON array of judge configs)
     eval_jury_judges: list[JudgeConfig] | None = None

--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,27 @@
 from functools import lru_cache
 
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 EMBEDDING_DIMENSIONS = 768
 CHUNK_SIZE = 1000
 CHUNK_OVERLAP = 200
+
+
+class JudgeConfig(BaseModel):
+    """Configuration for a single LLM judge in the evaluation jury.
+
+    Attributes:
+        model: Model name (e.g. "gpt-4o", "claude-sonnet").
+        provider: LangChain provider id (e.g. "openai", "anthropic").
+        api_key_field: Name of a SecretStr field on Settings holding the API key.
+        base_url: Optional custom API endpoint. Empty string means use provider default.
+    """
+
+    model: str
+    provider: str
+    api_key_field: str
+    base_url: str = ""
 
 
 class Settings(BaseSettings):
@@ -35,6 +51,7 @@ class Settings(BaseSettings):
             eval_llm_provider: LLM provider for evaluations (default: openai).
             eval_llm_provider_base_url: Base URL for evaluation LLM provider API.
             eval_llm_api_key: API key for evaluation LLM (optional, falls back to openai_api_key).
+            eval_jury_judges: List of judge configurations for jury-of-judges evaluation (optional).
             langsmith_api_key: LangSmith API key for tracing (optional).
             langsmith_project: LangSmith project name (default: default).
     """
@@ -72,6 +89,9 @@ class Settings(BaseSettings):
     eval_llm_provider: str = "openai"
     eval_llm_provider_base_url: str = "https://api.openai.com/v1"
     eval_llm_api_key: SecretStr | None = None
+
+    # Jury-of-judges configuration (optional JSON array of judge configs)
+    eval_jury_judges: list[JudgeConfig] | None = None
 
     # LangSmith configuration
     langsmith_api_key: SecretStr | None = None

--- a/src/config.py
+++ b/src/config.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings):
     eval_llm_provider: str = "openai"
     eval_llm_provider_base_url: str = "https://api.openai.com/v1"
     eval_llm_api_key: SecretStr | None = None
+    # cerebras_api_key: SecretStr | None = None
 
     # Jury-of-judges configuration (optional JSON array of judge configs)
     eval_jury_judges: list[JudgeConfig] | None = None

--- a/src/config_test.py
+++ b/src/config_test.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import SecretStr
 
-from src.config import CHUNK_OVERLAP, CHUNK_SIZE, EMBEDDING_DIMENSIONS, Settings
+from src.config import (
+    CHUNK_OVERLAP,
+    CHUNK_SIZE,
+    EMBEDDING_DIMENSIONS,
+    JudgeConfig,
+    Settings,
+)
 
 
 def test_configuration_constants():
@@ -115,3 +121,43 @@ def test_settings_loads_supabase_anon_key(monkeypatch: pytest.MonkeyPatch) -> No
     settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
     assert settings.supabase_anon_key.get_secret_value() == "test-anon-key"
     assert isinstance(settings.supabase_anon_key, SecretStr)
+
+
+def test_settings_parses_eval_jury_judges(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Settings parses EVAL_JURY_JUDGES JSON into list[JudgeConfig]."""
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
+    monkeypatch.setenv("BOOKIFIED_BLOB_READ_WRITE_TOKEN", "test-blob")
+    monkeypatch.setenv(
+        "EVAL_JURY_JUDGES",
+        '[{"model":"gpt-4o","provider":"openai","api_key_field":"openai_api_key","base_url":""},{"model":"claude-sonnet","provider":"anthropic","api_key_field":"openai_api_key","base_url":"https://custom.api"}]',
+    )
+
+    settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
+
+    assert settings.eval_jury_judges is not None
+    assert len(settings.eval_jury_judges) == 2
+    assert settings.eval_jury_judges[0].model == "gpt-4o"
+    assert settings.eval_jury_judges[0].provider == "openai"
+    assert settings.eval_jury_judges[0].api_key_field == "openai_api_key"
+    assert settings.eval_jury_judges[1].model == "claude-sonnet"
+    assert settings.eval_jury_judges[1].base_url == "https://custom.api"
+
+
+def test_settings_eval_jury_judges_defaults_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings defaults eval_jury_judges to None when env var is absent."""
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
+    monkeypatch.setenv("BOOKIFIED_BLOB_READ_WRITE_TOKEN", "test-blob")
+    monkeypatch.delenv("EVAL_JURY_JUDGES", raising=False)
+
+    settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
+    assert settings.eval_jury_judges is None

--- a/src/eval/evaluators.py
+++ b/src/eval/evaluators.py
@@ -13,6 +13,7 @@ from langsmith.evaluation import EvaluationResult
 from langsmith.schemas import Example, Run
 
 from src.config import get_settings
+from src.eval.jury import minority_veto
 from src.prompts.manager import pull_eval_prompt
 from src.schemas.chat import RetrievedChunk
 
@@ -179,17 +180,27 @@ async def correctness(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
+    invoke_kwargs = {
+        "question": example_inputs["question"],
+        "expected": example_outputs["answer"],
+        "actual": run_outputs["answer"],
+    }
+
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        return await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=CorrectnessGrade,
+            invoke_kwargs=invoke_kwargs,
+            score_field="correct",
+            judges=settings.eval_jury_judges,
+        )
+
     grader = await _get_grader(
         "correctness", "sanctuary-eval-correctness", CorrectnessGrade
     )
-
-    grade: CorrectnessGrade = await grader.ainvoke(
-        {
-            "question": example_inputs["question"],
-            "expected": example_outputs["answer"],
-            "actual": run_outputs["answer"],
-        }
-    )
+    grade: CorrectnessGrade = await grader.ainvoke(invoke_kwargs)
 
     return EvaluationResult(
         key="correctness",
@@ -242,14 +253,24 @@ async def relevance(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
-    grader = await _get_grader("relevance", "sanctuary-eval-relevance", RelevanceGrade)
+    invoke_kwargs = {
+        "question": example_inputs["question"],
+        "answer": run_outputs["answer"],
+    }
 
-    grade: RelevanceGrade = await grader.ainvoke(
-        {
-            "question": example_inputs["question"],
-            "answer": run_outputs["answer"],
-        }
-    )
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        return await minority_veto(
+            key="relevance",
+            prompt_name="sanctuary-eval-relevance",
+            schema=RelevanceGrade,
+            invoke_kwargs=invoke_kwargs,
+            score_field="relevant",
+            judges=settings.eval_jury_judges,
+        )
+
+    grader = await _get_grader("relevance", "sanctuary-eval-relevance", RelevanceGrade)
+    grade: RelevanceGrade = await grader.ainvoke(invoke_kwargs)
 
     return EvaluationResult(
         key="relevance",
@@ -303,16 +324,26 @@ async def groundedness(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
+    invoke_kwargs = {
+        "answer": run_outputs["answer"],
+        "documents": _format_docs(run_outputs["documents"]),
+    }
+
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        return await minority_veto(
+            key="groundedness",
+            prompt_name="sanctuary-eval-groundedness",
+            schema=GroundedGrade,
+            invoke_kwargs=invoke_kwargs,
+            score_field="grounded",
+            judges=settings.eval_jury_judges,
+        )
+
     grader = await _get_grader(
         "groundedness", "sanctuary-eval-groundedness", GroundedGrade
     )
-
-    grade: GroundedGrade = await grader.ainvoke(
-        {
-            "answer": run_outputs["answer"],
-            "documents": _format_docs(run_outputs["documents"]),
-        }
-    )
+    grade: GroundedGrade = await grader.ainvoke(invoke_kwargs)
 
     return EvaluationResult(
         key="groundedness",
@@ -368,18 +399,28 @@ async def retrieval_relevance(run: Run, example: Example | None) -> EvaluationRe
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
+    invoke_kwargs = {
+        "question": example_inputs["question"],
+        "documents": _format_docs(run_outputs["documents"]),
+    }
+
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        return await minority_veto(
+            key="retrieval_relevance",
+            prompt_name="sanctuary-eval-retrieval-relevance",
+            schema=RetrievalRelevanceGrade,
+            invoke_kwargs=invoke_kwargs,
+            score_field="relevant",
+            judges=settings.eval_jury_judges,
+        )
+
     grader = await _get_grader(
         "retrieval_relevance",
         "sanctuary-eval-retrieval-relevance",
         RetrievalRelevanceGrade,
     )
-
-    grade: RetrievalRelevanceGrade = await grader.ainvoke(
-        {
-            "question": example_inputs["question"],
-            "documents": _format_docs(run_outputs["documents"]),
-        }
-    )
+    grade: RetrievalRelevanceGrade = await grader.ainvoke(invoke_kwargs)
 
     return EvaluationResult(
         key="retrieval_relevance",

--- a/src/eval/evaluators.py
+++ b/src/eval/evaluators.py
@@ -63,6 +63,46 @@ async def _get_grader(name: str, prompt_name: str, schema: type) -> Runnable:
         return _grader_cache[name]
 
 
+async def _execute_grade(
+    key: str,
+    prompt_name: str,
+    schema: type,
+    invoke_kwargs: dict[str, Any],
+    score_field: str,
+) -> EvaluationResult:
+    """Grade using jury-of-judges or a single grader, depending on config.
+
+    Args:
+        key: Evaluator key name (e.g. ``"correctness"``).
+        prompt_name: LangSmith prompt hub name for the grader prompt.
+        schema: TypedDict class for structured output.
+        invoke_kwargs: Arguments to pass to the grader chain.
+        score_field: Key in the grader output dict that holds the boolean grade.
+
+    Returns:
+        An ``EvaluationResult`` with score and explanation.
+    """
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        return await minority_veto(
+            key=key,
+            prompt_name=prompt_name,
+            schema=schema,
+            invoke_kwargs=invoke_kwargs,
+            score_field=score_field,
+            judges=settings.eval_jury_judges,
+        )
+
+    grader = await _get_grader(key, prompt_name, schema)
+    grade: dict[str, Any] = await grader.ainvoke(invoke_kwargs)
+
+    return EvaluationResult(
+        key=key,
+        score=1 if grade[score_field] else 0,
+        comment=grade["explanation"],
+    )
+
+
 def _get_outputs(
     obj: Run | Example | dict[str, Any] | None, attr: str
 ) -> dict[str, Any]:
@@ -180,32 +220,16 @@ async def correctness(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
-    invoke_kwargs = {
-        "question": example_inputs["question"],
-        "expected": example_outputs["answer"],
-        "actual": run_outputs["answer"],
-    }
-
-    settings = get_settings()
-    if settings.eval_jury_judges:
-        return await minority_veto(
-            key="correctness",
-            prompt_name="sanctuary-eval-correctness",
-            schema=CorrectnessGrade,
-            invoke_kwargs=invoke_kwargs,
-            score_field="correct",
-            judges=settings.eval_jury_judges,
-        )
-
-    grader = await _get_grader(
-        "correctness", "sanctuary-eval-correctness", CorrectnessGrade
-    )
-    grade: CorrectnessGrade = await grader.ainvoke(invoke_kwargs)
-
-    return EvaluationResult(
+    return await _execute_grade(
         key="correctness",
-        score=1 if grade["correct"] else 0,
-        comment=grade["explanation"],
+        prompt_name="sanctuary-eval-correctness",
+        schema=CorrectnessGrade,
+        invoke_kwargs={
+            "question": example_inputs["question"],
+            "expected": example_outputs["answer"],
+            "actual": run_outputs["answer"],
+        },
+        score_field="correct",
     )
 
 
@@ -253,29 +277,15 @@ async def relevance(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
-    invoke_kwargs = {
-        "question": example_inputs["question"],
-        "answer": run_outputs["answer"],
-    }
-
-    settings = get_settings()
-    if settings.eval_jury_judges:
-        return await minority_veto(
-            key="relevance",
-            prompt_name="sanctuary-eval-relevance",
-            schema=RelevanceGrade,
-            invoke_kwargs=invoke_kwargs,
-            score_field="relevant",
-            judges=settings.eval_jury_judges,
-        )
-
-    grader = await _get_grader("relevance", "sanctuary-eval-relevance", RelevanceGrade)
-    grade: RelevanceGrade = await grader.ainvoke(invoke_kwargs)
-
-    return EvaluationResult(
+    return await _execute_grade(
         key="relevance",
-        score=1 if grade["relevant"] else 0,
-        comment=grade["explanation"],
+        prompt_name="sanctuary-eval-relevance",
+        schema=RelevanceGrade,
+        invoke_kwargs={
+            "question": example_inputs["question"],
+            "answer": run_outputs["answer"],
+        },
+        score_field="relevant",
     )
 
 
@@ -324,31 +334,15 @@ async def groundedness(run: Run, example: Example | None) -> EvaluationResult:
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
-    invoke_kwargs = {
-        "answer": run_outputs["answer"],
-        "documents": _format_docs(run_outputs["documents"]),
-    }
-
-    settings = get_settings()
-    if settings.eval_jury_judges:
-        return await minority_veto(
-            key="groundedness",
-            prompt_name="sanctuary-eval-groundedness",
-            schema=GroundedGrade,
-            invoke_kwargs=invoke_kwargs,
-            score_field="grounded",
-            judges=settings.eval_jury_judges,
-        )
-
-    grader = await _get_grader(
-        "groundedness", "sanctuary-eval-groundedness", GroundedGrade
-    )
-    grade: GroundedGrade = await grader.ainvoke(invoke_kwargs)
-
-    return EvaluationResult(
+    return await _execute_grade(
         key="groundedness",
-        score=1 if grade["grounded"] else 0,
-        comment=grade["explanation"],
+        prompt_name="sanctuary-eval-groundedness",
+        schema=GroundedGrade,
+        invoke_kwargs={
+            "answer": run_outputs["answer"],
+            "documents": _format_docs(run_outputs["documents"]),
+        },
+        score_field="grounded",
     )
 
 
@@ -399,31 +393,13 @@ async def retrieval_relevance(run: Run, example: Example | None) -> EvaluationRe
             comment=f"Missing required keys: {', '.join(missing)}",
         )
 
-    invoke_kwargs = {
-        "question": example_inputs["question"],
-        "documents": _format_docs(run_outputs["documents"]),
-    }
-
-    settings = get_settings()
-    if settings.eval_jury_judges:
-        return await minority_veto(
-            key="retrieval_relevance",
-            prompt_name="sanctuary-eval-retrieval-relevance",
-            schema=RetrievalRelevanceGrade,
-            invoke_kwargs=invoke_kwargs,
-            score_field="relevant",
-            judges=settings.eval_jury_judges,
-        )
-
-    grader = await _get_grader(
-        "retrieval_relevance",
-        "sanctuary-eval-retrieval-relevance",
-        RetrievalRelevanceGrade,
-    )
-    grade: RetrievalRelevanceGrade = await grader.ainvoke(invoke_kwargs)
-
-    return EvaluationResult(
+    return await _execute_grade(
         key="retrieval_relevance",
-        score=1 if grade["relevant"] else 0,
-        comment=grade["explanation"],
+        prompt_name="sanctuary-eval-retrieval-relevance",
+        schema=RetrievalRelevanceGrade,
+        invoke_kwargs={
+            "question": example_inputs["question"],
+            "documents": _format_docs(run_outputs["documents"]),
+        },
+        score_field="relevant",
     )

--- a/src/eval/evaluators_test.py
+++ b/src/eval/evaluators_test.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langsmith.schemas import Example, Run
 
+from src.config import JudgeConfig
 from src.eval.evaluators import (
     correctness,
     groundedness,
@@ -32,6 +33,14 @@ def _make_example(
     return example
 
 
+def _make_judges() -> list[JudgeConfig]:
+    """Return a two-judge jury config for testing."""
+    return [
+        JudgeConfig(model="model-a", provider="openai", api_key_field="openai_api_key"),
+        JudgeConfig(model="model-b", provider="openai", api_key_field="openai_api_key"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_correctness_returns_true_when_grader_says_correct() -> None:
     """Correctness evaluator returns score 1 when the LLM grades the answer correct."""
@@ -43,7 +52,13 @@ async def test_correctness_returns_true_when_grader_says_correct() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await correctness(
             run=_make_run({"answer": "4"}),
             example=_make_example({"question": "What is 2+2?"}, {"answer": "4"}),
@@ -64,7 +79,13 @@ async def test_correctness_returns_false_when_grader_says_incorrect() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await correctness(
             run=_make_run({"answer": "5"}),
             example=_make_example({"question": "What is 2+2?"}, {"answer": "4"}),
@@ -83,6 +104,7 @@ async def test_correctness_uses_eval_api_key_when_set() -> None:
     mock_settings.eval_llm_provider_base_url = "https://api.openai.com/v1"
     mock_settings.eval_llm_api_key = MagicMock()
     mock_settings.eval_llm_api_key.get_secret_value.return_value = "eval-key-123"
+    mock_settings.eval_jury_judges = None
 
     mock_llm = MagicMock()
     mock_llm.with_structured_output.return_value = MagicMock()
@@ -127,7 +149,13 @@ async def test_relevance_returns_true_when_grader_says_relevant() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await relevance(
             run=_make_run({"answer": "Python is a programming language."}),
             example=_make_example({"question": "What is Python?"}, {}),
@@ -149,7 +177,13 @@ async def test_relevance_returns_false_when_grader_says_irrelevant() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await relevance(
             run=_make_run({"answer": "The sky is blue."}),
             example=_make_example({"question": "What is Python?"}, {}),
@@ -185,7 +219,13 @@ async def test_groundedness_returns_true_when_grader_says_grounded() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await groundedness(
             run=_make_run(
                 {
@@ -212,7 +252,13 @@ async def test_groundedness_returns_false_when_grader_says_not_grounded() -> Non
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await groundedness(
             run=_make_run(
                 {
@@ -253,7 +299,13 @@ async def test_retrieval_relevance_returns_true_when_docs_relevant() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await retrieval_relevance(
             run=_make_run({"documents": ["Python is a programming language."]}),
             example=_make_example({"question": "What is Python?"}, {}),
@@ -275,7 +327,13 @@ async def test_retrieval_relevance_returns_false_when_docs_irrelevant() -> None:
         }
     )
 
-    with patch("src.eval.evaluators._get_grader", return_value=mock_chain):
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+    ):
         result = await retrieval_relevance(
             run=_make_run({"documents": ["Recipe for chocolate cake."]}),
             example=_make_example({"question": "What is Python?"}, {}),
@@ -338,3 +396,167 @@ def test_format_docs_includes_page_numbers() -> None:
 
     assert "Document 1 (Page 10):\nContent 1" in formatted
     assert "Document 2 (Page 20):\nContent 2" in formatted
+
+
+@pytest.mark.asyncio
+async def test_correctness_delegates_to_jury_when_configured() -> None:
+    """Correctness evaluator calls minority_veto when jury judges are configured."""
+    expected_result = MagicMock()
+    expected_result.key = "correctness"
+    expected_result.score = 1
+
+    judges = _make_judges()
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = judges
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch(
+            "src.eval.evaluators.minority_veto",
+            new_callable=AsyncMock,
+            return_value=expected_result,
+        ) as mock_veto,
+    ):
+        result = await correctness(
+            run=_make_run({"answer": "4"}),
+            example=_make_example({"question": "2+2?"}, {"answer": "4"}),
+        )
+
+    assert result.score == 1
+    mock_veto.assert_awaited_once()
+    call_kwargs = mock_veto.call_args[1]
+    assert call_kwargs["key"] == "correctness"
+    assert call_kwargs["score_field"] == "correct"
+    assert call_kwargs["judges"] is judges
+    assert call_kwargs["invoke_kwargs"] == {
+        "question": "2+2?",
+        "expected": "4",
+        "actual": "4",
+    }
+
+
+@pytest.mark.asyncio
+async def test_relevance_delegates_to_jury_when_configured() -> None:
+    """Relevance evaluator calls minority_veto when jury judges are configured."""
+    expected_result = MagicMock()
+    expected_result.key = "relevance"
+    expected_result.score = 0
+
+    judges = _make_judges()
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = judges
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch(
+            "src.eval.evaluators.minority_veto",
+            new_callable=AsyncMock,
+            return_value=expected_result,
+        ) as mock_veto,
+    ):
+        result = await relevance(
+            run=_make_run({"answer": "Python is great"}),
+            example=_make_example({"question": "What is Python?"}, {}),
+        )
+
+    assert result.score == 0
+    mock_veto.assert_awaited_once()
+    call_kwargs = mock_veto.call_args[1]
+    assert call_kwargs["key"] == "relevance"
+    assert call_kwargs["score_field"] == "relevant"
+    assert call_kwargs["invoke_kwargs"] == {
+        "question": "What is Python?",
+        "answer": "Python is great",
+    }
+
+
+@pytest.mark.asyncio
+async def test_groundedness_delegates_to_jury_when_configured() -> None:
+    """Groundedness evaluator calls minority_veto when jury judges are configured."""
+    expected_result = MagicMock()
+    expected_result.key = "groundedness"
+    expected_result.score = 1
+
+    judges = _make_judges()
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = judges
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch(
+            "src.eval.evaluators.minority_veto",
+            new_callable=AsyncMock,
+            return_value=expected_result,
+        ) as mock_veto,
+    ):
+        result = await groundedness(
+            run=_make_run(
+                {"answer": "The sky is blue.", "documents": ["Sky is blue."]}
+            ),
+            example=_make_example({}, {}),
+        )
+
+    assert result.score == 1
+    mock_veto.assert_awaited_once()
+    call_kwargs = mock_veto.call_args[1]
+    assert call_kwargs["key"] == "groundedness"
+    assert call_kwargs["score_field"] == "grounded"
+    # documents must be formatted via _format_docs before passing to jury
+    assert "Document 1" in call_kwargs["invoke_kwargs"]["documents"]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_relevance_delegates_to_jury_when_configured() -> None:
+    """Retrieval relevance evaluator calls minority_veto when jury judges are configured."""
+    expected_result = MagicMock()
+    expected_result.key = "retrieval_relevance"
+    expected_result.score = 1
+
+    judges = _make_judges()
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = judges
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch(
+            "src.eval.evaluators.minority_veto",
+            new_callable=AsyncMock,
+            return_value=expected_result,
+        ) as mock_veto,
+    ):
+        result = await retrieval_relevance(
+            run=_make_run({"documents": ["Python info"]}),
+            example=_make_example({"question": "What is Python?"}, {}),
+        )
+
+    assert result.score == 1
+    mock_veto.assert_awaited_once()
+    call_kwargs = mock_veto.call_args[1]
+    assert call_kwargs["key"] == "retrieval_relevance"
+    assert call_kwargs["score_field"] == "relevant"
+    assert "Document 1" in call_kwargs["invoke_kwargs"]["documents"]
+
+
+@pytest.mark.asyncio
+async def test_correctness_uses_single_judge_without_jury() -> None:
+    """Correctness evaluator uses single grader when eval_jury_judges is None."""
+    mock_chain = MagicMock()
+    mock_chain.ainvoke = AsyncMock(
+        return_value={"explanation": "Correct.", "correct": True}
+    )
+
+    mock_settings = MagicMock()
+    mock_settings.eval_jury_judges = None
+
+    with (
+        patch("src.eval.evaluators.get_settings", return_value=mock_settings),
+        patch("src.eval.evaluators._get_grader", return_value=mock_chain),
+        patch("src.eval.evaluators.minority_veto") as mock_veto,
+    ):
+        result = await correctness(
+            run=_make_run({"answer": "4"}),
+            example=_make_example({"question": "2+2?"}, {"answer": "4"}),
+        )
+
+    assert result.score == 1
+    mock_veto.assert_not_called()

--- a/src/eval/jury.py
+++ b/src/eval/jury.py
@@ -1,0 +1,94 @@
+"""Jury-of-judges orchestration for multi-LLM evaluation.
+
+Runs each evaluator prompt through multiple LLM judges and applies
+Minority Veto aggregation: score is 1 only if ALL judges pass.
+"""
+
+import asyncio
+from typing import Any
+
+from langchain.chat_models import init_chat_model
+from langchain_core.runnables import Runnable
+from langsmith.evaluation import EvaluationResult
+
+from src.config import JudgeConfig, get_settings
+from src.prompts.manager import pull_eval_prompt
+
+
+async def _build_judge_grader(
+    judge: JudgeConfig, prompt_name: str, schema: type
+) -> Runnable:
+    """Build a grader chain for a specific judge configuration.
+
+    Args:
+        judge: The judge configuration specifying model, provider, and key.
+        prompt_name: LangSmith prompt hub name to pull.
+        schema: TypedDict class for structured output.
+
+    Returns:
+        A runnable chain that produces dicts matching ``schema``.
+    """
+    settings = get_settings()
+
+    api_key_secret = getattr(settings, judge.api_key_field, None)
+    api_key = api_key_secret.get_secret_value() if api_key_secret else None
+
+    llm = init_chat_model(
+        model=judge.model,
+        model_provider=judge.provider,
+        api_key=api_key,
+        base_url=judge.base_url or None,
+        temperature=0,
+    )
+
+    prompt = await pull_eval_prompt(prompt_name)
+    return prompt | llm.with_structured_output(schema)
+
+
+async def minority_veto(
+    key: str,
+    prompt_name: str,
+    schema: type,
+    invoke_kwargs: dict[str, Any],
+    score_field: str,
+    judges: list[JudgeConfig],
+) -> EvaluationResult:
+    """Run all jury judges and aggregate with Minority Veto.
+
+    Score is 1 only if every judge passes. If any single judge
+    returns a failing grade, the overall score is 0.
+
+    Args:
+        key: Evaluator key name (e.g. ``"correctness"``).
+        prompt_name: LangSmith prompt hub name for the grader prompt.
+        schema: TypedDict class for structured output.
+        invoke_kwargs: Arguments to pass to each grader chain.
+        score_field: Key in the grader output dict that holds the boolean grade.
+        judges: List of judge configurations to evaluate with.
+
+    Returns:
+        An ``EvaluationResult`` with aggregated score and all judges' explanations.
+    """
+
+    async def _grade_with_judge(
+        judge: JudgeConfig,
+    ) -> tuple[JudgeConfig, dict[str, Any]]:
+        grader = await _build_judge_grader(judge, prompt_name, schema)
+        return judge, await grader.ainvoke(invoke_kwargs)
+
+    results = await asyncio.gather(*[_grade_with_judge(j) for j in judges])
+
+    explanations: list[str] = []
+    all_pass = True
+    for judge, grade in results:
+        explanations.append(
+            f"[{judge.model}] {'pass' if grade[score_field] else 'fail'}: {grade['explanation']}"
+        )
+        if not grade[score_field]:
+            all_pass = False
+
+    return EvaluationResult(
+        key=key,
+        score=1 if all_pass else 0,
+        comment=" | ".join(explanations),
+    )

--- a/src/eval/jury.py
+++ b/src/eval/jury.py
@@ -10,15 +10,23 @@ from typing import Any
 from langchain.chat_models import init_chat_model
 from langchain_core.runnables import Runnable
 from langsmith.evaluation import EvaluationResult
+from pydantic import SecretStr
 
 from src.config import JudgeConfig, get_settings
 from src.prompts.manager import pull_eval_prompt
+
+_judge_grader_cache: dict[str, Runnable] = {}
+_judge_grader_lock: asyncio.Lock = asyncio.Lock()
 
 
 async def _build_judge_grader(
     judge: JudgeConfig, prompt_name: str, schema: type
 ) -> Runnable:
-    """Build a grader chain for a specific judge configuration.
+    """Return a cached grader chain for a specific judge configuration.
+
+    Builds the chain on first call for each ``(model, provider, prompt_name)``
+    combination and caches it. An ``asyncio.Lock`` ensures only one coroutine
+    performs initialization.
 
     Args:
         judge: The judge configuration specifying model, provider, and key.
@@ -27,22 +35,46 @@ async def _build_judge_grader(
 
     Returns:
         A runnable chain that produces dicts matching ``schema``.
+
+    Raises:
+        ValueError: If ``api_key_field`` does not exist on Settings or is not
+            a ``SecretStr``.
     """
-    settings = get_settings()
+    cache_key = f"{judge.model}:{judge.provider}:{prompt_name}"
+    if cache_key in _judge_grader_cache:
+        return _judge_grader_cache[cache_key]
 
-    api_key_secret = getattr(settings, judge.api_key_field, None)
-    api_key = api_key_secret.get_secret_value() if api_key_secret else None
+    async with _judge_grader_lock:
+        if cache_key in _judge_grader_cache:
+            return _judge_grader_cache[cache_key]
 
-    llm = init_chat_model(
-        model=judge.model,
-        model_provider=judge.provider,
-        api_key=api_key,
-        base_url=judge.base_url or None,
-        temperature=0,
-    )
+        settings = get_settings()
 
-    prompt = await pull_eval_prompt(prompt_name)
-    return prompt | llm.with_structured_output(schema)
+        api_key_secret = getattr(settings, judge.api_key_field, None)
+        if api_key_secret is None:
+            raise ValueError(
+                f"EVAL_JURY_JUDGES: api_key_field '{judge.api_key_field}' "
+                f"does not exist on Settings."
+            )
+        if not isinstance(api_key_secret, SecretStr):
+            raise ValueError(
+                f"EVAL_JURY_JUDGES: api_key_field '{judge.api_key_field}' "
+                f"is not a SecretStr field (got {type(api_key_secret).__name__}). "
+                f"It must reference a SecretStr field on Settings."
+            )
+        api_key = api_key_secret.get_secret_value()
+
+        llm = init_chat_model(
+            model=judge.model,
+            model_provider=judge.provider,
+            api_key=api_key,
+            base_url=judge.base_url or None,
+            temperature=0,
+        )
+
+        prompt = await pull_eval_prompt(prompt_name)
+        _judge_grader_cache[cache_key] = prompt | llm.with_structured_output(schema)
+        return _judge_grader_cache[cache_key]
 
 
 async def minority_veto(

--- a/src/eval/jury.py
+++ b/src/eval/jury.py
@@ -105,22 +105,37 @@ async def minority_veto(
     async def _grade_with_judge(
         judge: JudgeConfig,
     ) -> tuple[JudgeConfig, dict[str, Any]]:
+        """Run a single judge and return its config with the grade dict.
+
+        Args:
+            judge: The judge configuration to evaluate with.
+
+        Returns:
+            A tuple of the judge config and its structured grade output.
+        """
         grader = await _build_judge_grader(judge, prompt_name, schema)
         return judge, await grader.ainvoke(invoke_kwargs)
 
-    results = await asyncio.gather(*[_grade_with_judge(j) for j in judges])
+    results = await asyncio.gather(
+        *[_grade_with_judge(j) for j in judges], return_exceptions=True
+    )
 
     explanations: list[str] = []
     all_pass = True
-    for judge, grade in results:
-        explanations.append(
-            f"[{judge.model}] {'pass' if grade[score_field] else 'fail'}: {grade['explanation']}"
-        )
-        if not grade[score_field]:
+    for judge, result_item in zip(judges, results):
+        if isinstance(result_item, Exception):
+            explanations.append(f"[{judge.model}] fail: exception: {result_item}")
             all_pass = False
+        else:
+            _, grade = result_item
+            explanations.append(
+                f"[{judge.model}] {'pass' if grade[score_field] else 'fail'}: {grade['explanation']}"
+            )
+            if not grade[score_field]:
+                all_pass = False
 
     return EvaluationResult(
         key=key,
         score=1 if all_pass else 0,
-        comment=" | ".join(explanations),
+        comment="- " + "\n- ".join(explanations),
     )

--- a/src/eval/jury.py
+++ b/src/eval/jury.py
@@ -24,7 +24,8 @@ async def _build_judge_grader(
 ) -> Runnable:
     """Return a cached grader chain for a specific judge configuration.
 
-    Builds the chain on first call for each ``(model, provider, prompt_name)``
+    Builds the chain on first call for each
+    ``(model, provider, api_key_field, base_url, prompt_name)``
     combination and caches it. An ``asyncio.Lock`` ensures only one coroutine
     performs initialization.
 
@@ -40,7 +41,7 @@ async def _build_judge_grader(
         ValueError: If ``api_key_field`` does not exist on Settings or is not
             a ``SecretStr``.
     """
-    cache_key = f"{judge.model}:{judge.provider}:{prompt_name}"
+    cache_key = f"{judge.model}:{judge.provider}:{judge.api_key_field}:{judge.base_url}:{prompt_name}"
     if cache_key in _judge_grader_cache:
         return _judge_grader_cache[cache_key]
 

--- a/src/eval/jury_test.py
+++ b/src/eval/jury_test.py
@@ -1,0 +1,123 @@
+"""Tests for the jury-of-judges evaluation orchestration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langsmith.evaluation import EvaluationResult
+
+from src.config import JudgeConfig
+from src.eval.jury import _build_judge_grader, minority_veto
+
+
+def _make_judges() -> list[JudgeConfig]:
+    """Return a two-judge jury config for testing."""
+    return [
+        JudgeConfig(model="model-a", provider="openai", api_key_field="openai_api_key"),
+        JudgeConfig(model="model-b", provider="openai", api_key_field="openai_api_key"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_minority_veto_all_pass() -> None:
+    """minority_veto returns score=1 when every judge passes."""
+    mock_grader = MagicMock()
+    mock_grader.ainvoke = AsyncMock(
+        return_value={"explanation": "Looks good", "correct": True}
+    )
+
+    with patch("src.eval.jury._build_judge_grader", return_value=mock_grader):
+        result = await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=dict,
+            invoke_kwargs={"question": "q", "expected": "a", "actual": "a"},
+            score_field="correct",
+            judges=_make_judges(),
+        )
+
+    assert isinstance(result, EvaluationResult)
+    assert result.score == 1
+    assert result.comment
+    assert "model-a" in result.comment
+    assert "model-b" in result.comment
+
+
+@pytest.mark.asyncio
+async def test_minority_veto_one_vetoes() -> None:
+    """minority_veto returns score=0 when any single judge fails."""
+    pass_grade = {"explanation": "Correct", "correct": True}
+    fail_grade = {"explanation": "Wrong", "correct": False}
+
+    mock_grader_pass = MagicMock()
+    mock_grader_pass.ainvoke = AsyncMock(return_value=pass_grade)
+    mock_grader_fail = MagicMock()
+    mock_grader_fail.ainvoke = AsyncMock(return_value=fail_grade)
+
+    async def _fake_build(judge, prompt_name, schema):
+        if judge.model == "model-a":
+            return mock_grader_pass
+        return mock_grader_fail
+
+    with patch("src.eval.jury._build_judge_grader", side_effect=_fake_build):
+        result = await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=dict,
+            invoke_kwargs={"question": "q", "expected": "a", "actual": "b"},
+            score_field="correct",
+            judges=_make_judges(),
+        )
+
+    assert result.score == 0
+    assert result.comment
+    assert "Wrong" in result.comment
+
+
+@pytest.mark.asyncio
+async def test_minority_veto_all_fail() -> None:
+    """minority_veto returns score=0 when all judges fail."""
+    mock_grader = MagicMock()
+    mock_grader.ainvoke = AsyncMock(
+        return_value={"explanation": "Incorrect", "correct": False}
+    )
+
+    with patch("src.eval.jury._build_judge_grader", return_value=mock_grader):
+        result = await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=dict,
+            invoke_kwargs={"question": "q", "expected": "a", "actual": "x"},
+            score_field="correct",
+            judges=_make_judges(),
+        )
+
+    assert result.score == 0
+
+
+@pytest.mark.asyncio
+async def test_build_judge_grader_resolves_api_key() -> None:
+    """_build_judge_grader reads the API key from the Settings field named in api_key_field."""
+    mock_settings = MagicMock()
+    mock_settings.openai_api_key = MagicMock()
+    mock_settings.openai_api_key.get_secret_value.return_value = "sk-jury-key"
+
+    mock_llm = MagicMock()
+    mock_llm.with_structured_output.return_value = MagicMock()
+    mock_prompt = MagicMock()
+    mock_prompt.__or__ = MagicMock(return_value=MagicMock())
+
+    judge = JudgeConfig(
+        model="gpt-4o", provider="openai", api_key_field="openai_api_key"
+    )
+
+    with (
+        patch("src.eval.jury.get_settings", return_value=mock_settings),
+        patch("src.eval.jury.init_chat_model", return_value=mock_llm) as mock_init,
+        patch("src.eval.jury.pull_eval_prompt", return_value=mock_prompt),
+    ):
+        await _build_judge_grader(judge, "sanctuary-eval-correctness", dict)
+
+    mock_init.assert_called_once()
+    assert mock_init.call_args[1]["api_key"] == "sk-jury-key"
+    assert mock_init.call_args[1]["model"] == "gpt-4o"
+    assert mock_init.call_args[1]["model_provider"] == "openai"

--- a/src/eval/jury_test.py
+++ b/src/eval/jury_test.py
@@ -55,6 +55,7 @@ async def test_minority_veto_one_vetoes() -> None:
     mock_grader_fail.ainvoke = AsyncMock(return_value=fail_grade)
 
     async def _fake_build(judge, prompt_name, schema):
+        """Return a passing grader for model-a and a failing one otherwise."""
         if judge.model == "model-a":
             return mock_grader_pass
         return mock_grader_fail
@@ -123,3 +124,64 @@ async def test_build_judge_grader_resolves_api_key() -> None:
     assert mock_init.call_args[1]["api_key"] == "sk-jury-key"
     assert mock_init.call_args[1]["model"] == "gpt-4o"
     assert mock_init.call_args[1]["model_provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_minority_veto_judge_exception_returns_score_zero() -> None:
+    """minority_veto returns score=0 and includes failure message when a judge raises."""
+    pass_grade = {"explanation": "Correct", "correct": True}
+
+    mock_grader_pass = MagicMock()
+    mock_grader_pass.ainvoke = AsyncMock(return_value=pass_grade)
+
+    mock_grader_fail = MagicMock()
+    mock_grader_fail.ainvoke = AsyncMock(side_effect=RuntimeError("LLM timeout"))
+
+    async def _fake_build(judge, prompt_name, schema):
+        """Return a passing grader for model-a and a failing one for model-b."""
+        if judge.model == "model-a":
+            return mock_grader_pass
+        return mock_grader_fail
+
+    with patch("src.eval.jury._build_judge_grader", side_effect=_fake_build):
+        result = await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=dict,
+            invoke_kwargs={"question": "q", "expected": "a", "actual": "a"},
+            score_field="correct",
+            judges=_make_judges(),
+        )
+
+    assert result.score == 0
+    assert result.comment is not None
+    assert "model-b" in result.comment
+    assert "exception" in result.comment.lower()
+
+
+@pytest.mark.asyncio
+async def test_minority_veto_build_grader_exception_returns_score_zero() -> None:
+    """minority_veto returns score=0 when _build_judge_grader itself raises."""
+
+    async def _fake_build(judge, prompt_name, schema):
+        """Raise for model-b, succeed for model-a."""
+        if judge.model == "model-b":
+            raise ValueError("bad api key field")
+        grader = MagicMock()
+        grader.ainvoke = AsyncMock(return_value={"explanation": "OK", "correct": True})
+        return grader
+
+    with patch("src.eval.jury._build_judge_grader", side_effect=_fake_build):
+        result = await minority_veto(
+            key="correctness",
+            prompt_name="sanctuary-eval-correctness",
+            schema=dict,
+            invoke_kwargs={"question": "q", "expected": "a", "actual": "a"},
+            score_field="correct",
+            judges=_make_judges(),
+        )
+
+    assert result.score == 0
+    assert result.comment is not None
+    assert "model-b" in result.comment
+    assert "exception" in result.comment.lower()

--- a/src/eval/jury_test.py
+++ b/src/eval/jury_test.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langsmith.evaluation import EvaluationResult
+from pydantic import SecretStr
 
 from src.config import JudgeConfig
-from src.eval.jury import _build_judge_grader, minority_veto
+from src.eval.jury import _build_judge_grader, _judge_grader_cache, minority_veto
 
 
 def _make_judges() -> list[JudgeConfig]:
@@ -98,8 +99,7 @@ async def test_minority_veto_all_fail() -> None:
 async def test_build_judge_grader_resolves_api_key() -> None:
     """_build_judge_grader reads the API key from the Settings field named in api_key_field."""
     mock_settings = MagicMock()
-    mock_settings.openai_api_key = MagicMock()
-    mock_settings.openai_api_key.get_secret_value.return_value = "sk-jury-key"
+    mock_settings.openai_api_key = SecretStr("sk-jury-key")
 
     mock_llm = MagicMock()
     mock_llm.with_structured_output.return_value = MagicMock()
@@ -109,6 +109,8 @@ async def test_build_judge_grader_resolves_api_key() -> None:
     judge = JudgeConfig(
         model="gpt-4o", provider="openai", api_key_field="openai_api_key"
     )
+
+    _judge_grader_cache.clear()
 
     with (
         patch("src.eval.jury.get_settings", return_value=mock_settings),

--- a/src/eval/run.py
+++ b/src/eval/run.py
@@ -10,6 +10,7 @@ import asyncio
 from dotenv import load_dotenv
 from langsmith import Client, aevaluate
 
+from src.config import get_settings
 from src.eval.dataset import ensure_dataset
 from src.eval.evaluators import (
     correctness,
@@ -28,6 +29,13 @@ async def main() -> None:
     evaluator.
     """
     load_dotenv()
+
+    settings = get_settings()
+    if settings.eval_jury_judges:
+        judge_names = [j.model for j in settings.eval_jury_judges]
+        print(f"Jury mode: {len(judge_names)} judges — {', '.join(judge_names)}")
+    else:
+        print("Single-judge mode (no EVAL_JURY_JUDGES configured)")
 
     client = Client()
     dataset_name = ensure_dataset(client)


### PR DESCRIPTION
Resolve #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Jury-of-judges evaluation with a "Minority Veto" policy (all judges must pass)
  - Multi-LLM judge support with per-judge model/provider/endpoint/API-key configuration
  - Startup console reporting indicating jury vs single-judge mode and configured judges

* **Documentation**
  - Updated environment example and guidance for configuring the jury via EVAL_JURY_JUDGES

* **Tests**
  - Added tests covering jury orchestration, grader building, and both jury and single-judge paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->