### PR TITLE
feat(rag): implement strategy pattern for RAG pipelines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ EVAL_LLM_PROVIDER=
 EVAL_LLM_PROVIDER_BASE_URL=
 EVAL_LLM_API_KEY=
 
+# RAG strategy: naive_rag | query_rewrite | multi_query | agentic
+RAG_STRATEGY=naive_rag
+
 # Jury-of-judges evaluation (optional, minimum 2 entries)
 # When set, each evaluator runs through ALL judges.
 # Strategy: Minority Veto — score is PASS only if every judge passes.

--- a/src/config.py
+++ b/src/config.py
@@ -91,6 +91,9 @@ class Settings(BaseSettings):
     eval_llm_api_key: SecretStr | None = None
     cerebras_api_key: SecretStr | None = None
 
+    # RAG strategy selection for experimentation
+    rag_strategy: str = "naive_rag"
+
     # Jury-of-judges configuration (optional JSON array of judge configs)
     eval_jury_judges: list[JudgeConfig] | None = None
 

--- a/src/config.py
+++ b/src/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
             eval_llm_provider: LLM provider for evaluations (default: openai).
             eval_llm_provider_base_url: Base URL for evaluation LLM provider API.
             eval_llm_api_key: API key for evaluation LLM (optional, falls back to openai_api_key).
+            rag_strategy: RAG pipeline strategy to use (default: naive_rag).
             eval_jury_judges: List of judge configurations for jury-of-judges evaluation (optional).
             langsmith_api_key: LangSmith API key for tracing (optional).
             langsmith_project: LangSmith project name (default: default).

--- a/src/config_test.py
+++ b/src/config_test.py
@@ -161,3 +161,35 @@ def test_settings_eval_jury_judges_defaults_to_none(
 
     settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
     assert settings.eval_jury_judges is None
+
+
+def test_settings_rag_strategy_defaults_to_naive_rag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings.rag_strategy defaults to 'naive_rag'."""
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
+    monkeypatch.setenv("BOOKIFIED_BLOB_READ_WRITE_TOKEN", "test-blob")
+    monkeypatch.delenv("RAG_STRATEGY", raising=False)
+
+    settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
+    assert settings.rag_strategy == "naive_rag"
+
+
+def test_settings_rag_strategy_reads_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings.rag_strategy reads from RAG_STRATEGY env var."""
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
+    monkeypatch.setenv("BOOKIFIED_BLOB_READ_WRITE_TOKEN", "test-blob")
+    monkeypatch.setenv("RAG_STRATEGY", "query_rewrite")
+
+    settings = Settings(_env_file=None)  # ty:ignore[missing-argument,unknown-argument]
+    assert settings.rag_strategy == "query_rewrite"

--- a/src/services/retrieval.py
+++ b/src/services/retrieval.py
@@ -204,7 +204,14 @@ async def stream_rag_pipeline(
         ChunksEvent with retrieved documents, then TokenEvent and CitationsEvent.
     """
     settings = get_settings()
-    strategy = get_strategy(settings.rag_strategy)
+    try:
+        strategy = get_strategy(settings.rag_strategy)
+    except ValueError:
+        logger.warning(
+            "Unknown RAG strategy '%s', falling back to 'naive_rag'",
+            settings.rag_strategy,
+        )
+        strategy = get_strategy("naive_rag")
 
     async for event in strategy(
         query=query,

--- a/src/services/retrieval.py
+++ b/src/services/retrieval.py
@@ -19,6 +19,7 @@ from src.schemas.chat import (
     StreamEvent,
     TokenEvent,
 )
+from src.services.strategies.registry import get_strategy
 from supabase import AsyncClient
 
 logger = logging.getLogger(__name__)
@@ -187,37 +188,29 @@ async def stream_rag_pipeline(
     *,
     client: AsyncClient | None = None,
 ) -> AsyncGenerator[StreamEvent, None]:
-    """Retrieve chunks then stream the LLM answer with citations.
+    """Dispatch to the configured RAG strategy and stream results.
 
-    Eagerly calls ``retrieve_chunks``, then yields ``StreamEvent`` items
-    from ``stream_answer_with_citations``.  This is the single entry point
-    for the full RAG pipeline — used by both the chat router (streaming)
-    and the eval target (drained to collect the final result).
+    Reads ``settings.rag_strategy`` to select the pipeline variant.
+    Each strategy must yield ``ChunksEvent``, then ``TokenEvent``/``CitationsEvent``.
 
     Args:
         query: The user's question.
         document_id: UUID of the document to search within.
         user_id: UUID of the user (for authorization).
         k: Number of chunks to retrieve.
-        client: Optional Supabase client to reuse for requests.
+        client: Optional Supabase client to reuse.
 
     Yields:
         ChunksEvent with retrieved documents, then TokenEvent and CitationsEvent.
     """
-    chunks = await retrieve_chunks(
-        query=query,  # ty: ignore[invalid-argument-type]
-        document_id=document_id,  # ty: ignore[invalid-argument-type]
-        user_id=user_id,  # ty: ignore[invalid-argument-type]
-        k=k,  # ty: ignore[invalid-argument-type]
-        client=client,  # ty: ignore[invalid-argument-type]
-    )
+    settings = get_settings()
+    strategy = get_strategy(settings.rag_strategy)
 
-    yield ChunksEvent(
-        chunks=[
-            RetrievedChunk(page_content=c.page_content, page=c.metadata.get("page"))
-            for c in chunks
-        ]
-    )
-
-    async for event in stream_answer_with_citations(query=query, chunks=chunks):  # ty: ignore
+    async for event in strategy(
+        query=query,
+        document_id=document_id,
+        user_id=user_id,
+        k=k,
+        client=client,
+    ):
         yield event

--- a/src/services/retrieval_test.py
+++ b/src/services/retrieval_test.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from src.schemas.chat import (
     Citation,
     CitationsEvent,
     RetrievedChunk,
+    StreamEvent,
     TokenEvent,
 )
 from src.services.retrieval import (
@@ -368,15 +370,22 @@ async def test_stream_rag_pipeline_yields_events():
 
 
 @pytest.mark.asyncio
-async def test_stream_rag_pipeline_dispatches_to_configured_strategy():
+async def test_stream_rag_pipeline_dispatches_to_configured_strategy() -> None:
     """stream_rag_pipeline delegates to the strategy from settings.rag_strategy."""
-    fake_events = [
+    fake_events: list[StreamEvent] = [
         ChunksEvent(chunks=[]),
         TokenEvent(token="dispatched"),
         CitationsEvent(citations=[]),
     ]
 
-    async def fake_execute(query, document_id, user_id, k=5, *, client=None):
+    async def fake_execute(
+        query: str,
+        document_id: str,
+        user_id: str,
+        k: int = 5,
+        *,
+        client: object | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
         for event in fake_events:
             yield event
 

--- a/src/services/retrieval_test.py
+++ b/src/services/retrieval_test.py
@@ -320,15 +320,17 @@ async def test_stream_rag_pipeline_yields_events():
 
     with (
         patch(
-            "src.services.retrieval.retrieve_chunks",
+            "src.services.strategies.naive_rag.retrieve_chunks",
             new_callable=AsyncMock,
             return_value=mock_chunks,
         ) as mock_retrieve,
         patch(
-            "src.services.retrieval.stream_answer_with_citations",
+            "src.services.strategies.naive_rag.stream_answer_with_citations",
             side_effect=fake_stream,
         ),
+        patch("src.services.retrieval.get_settings") as mock_settings,
     ):
+        mock_settings.return_value.rag_strategy = "naive_rag"
         mock_client = AsyncMock()
         results = [
             event
@@ -363,3 +365,40 @@ async def test_stream_rag_pipeline_yields_events():
         k=3,
         client=mock_client,
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_rag_pipeline_dispatches_to_configured_strategy():
+    """stream_rag_pipeline delegates to the strategy from settings.rag_strategy."""
+    fake_events = [
+        ChunksEvent(chunks=[]),
+        TokenEvent(token="dispatched"),
+        CitationsEvent(citations=[]),
+    ]
+
+    async def fake_execute(query, document_id, user_id, k=5, *, client=None):
+        for event in fake_events:
+            yield event
+
+    mock_settings = MagicMock()
+    mock_settings.rag_strategy = "naive_rag"
+
+    with (
+        patch("src.services.retrieval.get_settings", return_value=mock_settings),
+        patch(
+            "src.services.retrieval.get_strategy",
+            return_value=fake_execute,
+        ) as mock_get_strategy,
+    ):
+        results = [
+            event
+            async for event in stream_rag_pipeline(
+                query="test",  # ty: ignore[invalid-argument-type]
+                document_id="doc-1",  # ty: ignore[invalid-argument-type]
+                user_id="user-1",  # ty: ignore[invalid-argument-type]
+            )
+        ]
+
+    mock_get_strategy.assert_called_once_with("naive_rag")
+    assert len(results) == 3
+    assert results[1] == TokenEvent(token="dispatched")

--- a/src/services/strategies/naive_rag.py
+++ b/src/services/strategies/naive_rag.py
@@ -1,0 +1,52 @@
+"""Naive RAG strategy — direct retrieve then generate.
+
+This is the original pipeline logic extracted from retrieval.py.
+"""
+
+from collections.abc import AsyncGenerator
+
+from langsmith import traceable
+
+from src.schemas.chat import ChunksEvent, RetrievedChunk, StreamEvent
+from src.services.retrieval import retrieve_chunks, stream_answer_with_citations
+from supabase import AsyncClient
+
+
+@traceable(metadata={"rag_strategy": "naive_rag"})
+async def execute(
+    query: str,
+    document_id: str,
+    user_id: str,
+    k: int = 5,
+    *,
+    client: AsyncClient | None = None,
+) -> AsyncGenerator[StreamEvent, None]:
+    """Run the naive_rag RAG pipeline: retrieve chunks then stream answer.
+
+    Args:
+        query: The user's question.
+        document_id: UUID of the document to search within.
+        user_id: UUID of the user (for authorization).
+        k: Number of chunks to retrieve.
+        client: Optional Supabase client to reuse.
+
+    Yields:
+        ChunksEvent with retrieved documents, then TokenEvent and CitationsEvent.
+    """
+    chunks = await retrieve_chunks(
+        query=query,  # ty: ignore[invalid-argument-type]
+        document_id=document_id,  # ty: ignore[invalid-argument-type]
+        user_id=user_id,  # ty: ignore[invalid-argument-type]
+        k=k,  # ty: ignore[invalid-argument-type]
+        client=client,  # ty: ignore[invalid-argument-type]
+    )
+
+    yield ChunksEvent(
+        chunks=[
+            RetrievedChunk(page_content=c.page_content, page=c.metadata.get("page"))
+            for c in chunks
+        ]
+    )
+
+    async for event in stream_answer_with_citations(query=query, chunks=chunks):  # ty: ignore[invalid-argument-type]
+        yield event

--- a/src/services/strategies/naive_rag_test.py
+++ b/src/services/strategies/naive_rag_test.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+from src.schemas.chat import (
+    ChunksEvent,
+    Citation,
+    CitationsEvent,
+    RetrievedChunk,
+    TokenEvent,
+)
+from src.services.strategies.naive_rag import execute
+
+
+@pytest.mark.asyncio
+async def test_naive_rag_execute_yields_chunks_then_stream_events():
+    """naive_rag.execute yields ChunksEvent then delegates to stream_answer_with_citations."""
+    mock_chunks = [
+        Document(page_content="chunk one", metadata={"page": 1}),
+    ]
+
+    fake_events = [
+        TokenEvent(token="Hello "),
+        TokenEvent(token="world."),
+        CitationsEvent(citations=[Citation(page=1)]),
+    ]
+
+    async def fake_stream(query, chunks):
+        for event in fake_events:
+            yield event
+
+    with (
+        patch(
+            "src.services.strategies.naive_rag.retrieve_chunks",
+            new_callable=AsyncMock,
+            return_value=mock_chunks,
+        ) as mock_retrieve,
+        patch(
+            "src.services.strategies.naive_rag.stream_answer_with_citations",
+            side_effect=fake_stream,
+        ),
+    ):
+        mock_client = AsyncMock()
+        results = [
+            event
+            async for event in execute(
+                query="Hi",  # ty: ignore[invalid-argument-type]
+                document_id="doc-1",  # ty: ignore[invalid-argument-type]
+                user_id="user-1",  # ty: ignore[invalid-argument-type]
+                k=3,  # ty: ignore[invalid-argument-type]
+                client=mock_client,
+            )
+        ]
+
+    assert len(results) == 4
+
+    assert isinstance(results[0], ChunksEvent)
+    assert results[0].chunks == [RetrievedChunk(page_content="chunk one", page=1)]
+
+    assert results[1] == TokenEvent(token="Hello ")
+    assert results[2] == TokenEvent(token="world.")
+    assert isinstance(results[3], CitationsEvent)
+
+    mock_retrieve.assert_called_once_with(
+        query="Hi",
+        document_id="doc-1",
+        user_id="user-1",
+        k=3,
+        client=mock_client,
+    )

--- a/src/services/strategies/registry.py
+++ b/src/services/strategies/registry.py
@@ -1,0 +1,35 @@
+"""Strategy registry for RAG pipeline variants."""
+
+from collections.abc import AsyncGenerator, Callable
+
+from src.schemas.chat import StreamEvent
+
+# Type alias for a strategy execute function
+StrategyFn = Callable[
+    ...,
+    AsyncGenerator[StreamEvent, None],
+]
+
+
+def get_strategy(name: str) -> StrategyFn:
+    """Return the execute function for the given strategy name.
+
+    Args:
+        name: Strategy identifier (e.g. 'naive_rag', 'query_rewrite').
+
+    Returns:
+        The async generator function for the named strategy.
+
+    Raises:
+        ValueError: If the strategy name is not registered.
+    """
+    from src.services.strategies.naive_rag import execute as naive_rag_execute
+
+    registry: dict[str, StrategyFn] = {
+        "naive_rag": naive_rag_execute,
+    }
+
+    if name not in registry:
+        raise ValueError(f"Unknown RAG strategy: '{name}'")
+
+    return registry[name]

--- a/src/services/strategies/registry_test.py
+++ b/src/services/strategies/registry_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.services.strategies.registry import get_strategy
+
+
+def test_get_strategy_returns_naive_rag():
+    """get_strategy('naive_rag') returns the naive_rag execute function."""
+    strategy = get_strategy("naive_rag")
+    assert callable(strategy)
+    assert strategy.__module__ == "src.services.strategies.naive_rag"
+
+
+def test_get_strategy_unknown_raises_value_error():
+    """get_strategy raises ValueError for unknown strategy names."""
+    with pytest.raises(ValueError, match="Unknown RAG strategy: 'nonexistent'"):
+        get_strategy("nonexistent")


### PR DESCRIPTION
Fix #22 

- Add RAG_STRATEGY_DEFAULT environment variable for strategy selection
- Create strategy registry with pluggable architecture
- Extract naive_rag strategy from retrieval.py into dedicated module
- Update stream_rag_pipeline to use strategy pattern with fallback
- Add comprehensive test coverage for registry and naive_rag strategy
- Maintain backward compatibility with existing API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable RAG strategy selection via environment, with selectable approaches (`naive_rag`, `query_rewrite`, `multi_query`, `agentic`).

* **Documentation**
  * Example environment configuration updated to show the new RAG strategy setting and default.

* **Bug Fixes**
  * Invalid strategy values now trigger a safe fallback to the default strategy.

* **Tests**
  * Added tests covering strategy configuration, dispatch, and the new default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->