### PR TITLE
feat: implement agentic RAG strategy with agent-based retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ EVAL_LLM_PROVIDER=
 EVAL_LLM_PROVIDER_BASE_URL=
 EVAL_LLM_API_KEY=
 
-# RAG strategy: naive_rag | query_rewrite | multi_query | self_correcting | agentic
+# RAG strategy: naive_rag | query_rewrite | multi_query | self_correcting | agentic_rag
 RAG_STRATEGY=
 
 # Jury-of-judges evaluation (optional, minimum 2 entries)

--- a/src/config.py
+++ b/src/config.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
             min_similarity: Minimum similarity threshold for retrieval.
             max_retries: Maximum number of retries for the self-correcting RAG strategy (default: 3).
             min_relevant_chunks: Minimum number of relevant chunks required for the self-correcting RAG strategy (default: 3).
-            agentic_rag_max_iterations: Maximum recursion steps for the agentic RAG agent (default: 10).
+            max_tool_calls: Maximum tool calls for the agentic RAG agent (default: 5).
             cors_origins: List of allowed CORS origins.
             eval_llm_model: Language model to use for evaluations (default: gpt-4o-mini).
             eval_llm_provider: LLM provider for evaluations (default: openai).
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     min_similarity: float = 0.6
     max_retries: int = 3
     min_relevant_chunks: int = 3
-    agentic_rag_max_iterations: int = 10
+    max_tool_calls: int = 5
 
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/config.py
+++ b/src/config.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
             min_similarity: Minimum similarity threshold for retrieval.
             max_retries: Maximum number of retries for the self-correcting RAG strategy (default: 3).
             min_relevant_chunks: Minimum number of relevant chunks required for the self-correcting RAG strategy (default: 3).
-            agentic_rag_max_iterations: Maximum recursion steps for the agentic RAG agent (default: 15).
+            agentic_rag_max_iterations: Maximum recursion steps for the agentic RAG agent (default: 10).
             cors_origins: List of allowed CORS origins.
             eval_llm_model: Language model to use for evaluations (default: gpt-4o-mini).
             eval_llm_provider: LLM provider for evaluations (default: openai).

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
             min_similarity: Minimum similarity threshold for retrieval.
             max_retries: Maximum number of retries for the self-correcting RAG strategy (default: 3).
             min_relevant_chunks: Minimum number of relevant chunks required for the self-correcting RAG strategy (default: 3).
+            agentic_rag_max_iterations: Maximum recursion steps for the agentic RAG agent (default: 15).
             cors_origins: List of allowed CORS origins.
             eval_llm_model: Language model to use for evaluations (default: gpt-4o-mini).
             eval_llm_provider: LLM provider for evaluations (default: openai).
@@ -88,6 +89,7 @@ class Settings(BaseSettings):
     min_similarity: float = 0.6
     max_retries: int = 3
     min_relevant_chunks: int = 3
+    agentic_rag_max_iterations: int = 10
 
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/prompts/manager.py
+++ b/src/prompts/manager.py
@@ -139,6 +139,30 @@ RETRIEVAL_GRADING_PROMPT_HARDCODED = ChatPromptTemplate.from_messages(
     ]
 )
 
+AGENTIC_RAG_PROMPT_HARDCODED = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a research assistant that answers questions based ONLY on the "
+            "content retrieved via the search_docs tool. Do not use any outside "
+            "knowledge. If the answer cannot be found in the retrieved content, say so.\n\n"
+            "The search_docs tool returns passages prefixed with [Page X] indicating "
+            "their source page number.\n\n"
+            "Guidelines:\n"
+            "- Be specific with your search queries (3-8 words)\n"
+            "- Try different angles if one query returns nothing\n"
+            "- When you have gathered enough information, stop searching and answer "
+            "the question directly\n"
+            "- Do not repeat the same search query\n"
+            "- Always cite your sources using [p. X] format where X is the page number",
+        ),
+        (
+            "human",
+            "{query}",
+        ),
+    ]
+)
+
 FALLBACK_PROMPTS: dict[str, ChatPromptTemplate] = {
     "sanctuary-eval-correctness": CORRECTNESS_PROMPT_HARDCODED,
     "sanctuary-eval-relevance": RELEVANCE_PROMPT_HARDCODED,
@@ -148,6 +172,7 @@ FALLBACK_PROMPTS: dict[str, ChatPromptTemplate] = {
     "sanctuary-query-rewrite": QUERY_REWRITE_PROMPT_HARDCODED,
     "sanctuary-multi-query": MULTI_QUERY_PROMPT_HARDCODED,
     "sanctuary-retrieval-grading": RETRIEVAL_GRADING_PROMPT_HARDCODED,
+    "sanctuary-agentic-rag": AGENTIC_RAG_PROMPT_HARDCODED,
 }
 
 

--- a/src/prompts/manager_test.py
+++ b/src/prompts/manager_test.py
@@ -130,6 +130,16 @@ def test_retrieval_grading_prompt_has_required_variables() -> None:
     assert "document" in prompt.input_variables
 
 
+def test_agentic_rag_prompt_fallback_exists():
+    """The agentic RAG prompt fallback should be registered."""
+    from src.prompts.manager import AGENTIC_RAG_PROMPT_HARDCODED
+
+    assert "sanctuary-agentic-rag" in FALLBACK_PROMPTS
+    assert FALLBACK_PROMPTS["sanctuary-agentic-rag"] is AGENTIC_RAG_PROMPT_HARDCODED
+    messages = AGENTIC_RAG_PROMPT_HARDCODED.messages
+    assert len(messages) >= 2
+
+
 @patch("src.prompts.manager._get_client")
 def test_push_eval_prompts_logs_error_on_failure(
     mock_get_client: MagicMock,

--- a/src/prompts/manager_test.py
+++ b/src/prompts/manager_test.py
@@ -130,7 +130,7 @@ def test_retrieval_grading_prompt_has_required_variables() -> None:
     assert "document" in prompt.input_variables
 
 
-def test_agentic_rag_prompt_fallback_exists():
+def test_agentic_rag_prompt_fallback_exists() -> None:
     """The agentic RAG prompt fallback should be registered."""
     from src.prompts.manager import AGENTIC_RAG_PROMPT_HARDCODED
 

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -13,8 +13,10 @@ from typing import Any
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessageChunk
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
+from langgraph.graph.state import CompiledStateGraph
 from langsmith import traceable
 
 from src.config import get_settings
@@ -39,7 +41,7 @@ def _make_search_tool(
     k: int,
     client: AsyncClient | None,
     accumulated_chunks: list[Document],
-):
+) -> Any:
     """Create a search tool bound to the current retrieval context.
 
     The tool accumulates retrieved chunks (deduplicated) into the
@@ -101,7 +103,7 @@ async def _build_agent(
     k: int,
     client: AsyncClient | None,
     accumulated_chunks: list[Document],
-):
+) -> CompiledStateGraph:
     """Build the agentic RAG agent with a search tool.
 
     Args:
@@ -122,6 +124,7 @@ async def _build_agent(
         api_key=settings.openai_api_key.get_secret_value(),
         base_url=settings.llm_provider_base_url,
         temperature=0,
+        streaming=True,
     )
 
     search_tool = _make_search_tool(
@@ -182,7 +185,7 @@ async def execute(
     )
 
     settings = get_settings()
-    config: dict[str, Any] = {
+    config: RunnableConfig = {
         "configurable": {"thread_id": f"agentic-rag-{document_id}-{user_id}"},
         "recursion_limit": settings.agentic_rag_max_iterations,
     }
@@ -195,11 +198,12 @@ async def execute(
         config=config,
         stream_mode="messages",
     ):
-        if not isinstance(msg, AIMessageChunk):
+        # Accept both streamed chunks and final messages
+        if not isinstance(msg, (AIMessageChunk, AIMessage)):
             continue
 
         # Skip tool-call chunks (intermediate reasoning)
-        if msg.tool_call_chunks:
+        if isinstance(msg, AIMessageChunk) and msg.tool_call_chunks:
             continue
 
         # Yield chunks once, right before the first final-answer token

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -233,7 +233,8 @@ async def execute(
         client: Optional Supabase client to reuse.
 
     Yields:
-        ChunksEvent with final documents, then TokenEvent and CitationsEvent.
+        TokenEvent for streamed answer tokens, then ChunksEvent with final
+        documents, and CitationsEvent.
     """
     settings = get_settings()
     accumulated: list[Document] = []
@@ -252,7 +253,6 @@ async def execute(
         "configurable": {"thread_id": f"agentic-rag-{document_id}-{user_id}"},
     }
 
-    chunks_yielded = False
     full_answer = ""
 
     async for msg, metadata in agent.astream(
@@ -260,34 +260,22 @@ async def execute(
         config=config,
         stream_mode="messages",
     ):
-        # Accept both streamed chunks and final messages
-        if not isinstance(msg, (AIMessageChunk, AIMessage)):
-            continue
+        if isinstance(msg, (AIMessageChunk, AIMessage)) and not (
+            isinstance(msg, AIMessageChunk) and msg.tool_call_chunks
+        ):
+            token = msg.content if isinstance(msg.content, str) else str(msg.content)
+            if token:
+                full_answer += token
+                yield TokenEvent(token=token)
 
-        # Skip tool-call chunks (intermediate reasoning)
-        if isinstance(msg, AIMessageChunk) and msg.tool_call_chunks:
-            continue
-
-        # Yield chunks once, right before the first final-answer token
-        if not chunks_yielded:
-            chunks_yielded = True
-            yield ChunksEvent(
-                chunks=[
-                    RetrievedChunk(
-                        page_content=c.page_content, page=c.metadata.get("page")
-                    )
-                    for c in accumulated
-                ]
-            )
-
-        token = msg.content if isinstance(msg.content, str) else str(msg.content)
-        if token:
-            full_answer += token
-            yield TokenEvent(token=token)
-
-    # If the agent never produced a final answer (e.g. no chunks found)
-    if not chunks_yielded:
-        yield ChunksEvent(chunks=[])
+    # Yield ChunksEvent after streaming completes, so all accumulated
+    # chunks are available and the event ordering is deterministic.
+    yield ChunksEvent(
+        chunks=[
+            RetrievedChunk(page_content=c.page_content, page=c.metadata.get("page"))
+            for c in accumulated
+        ]
+    )
 
     if not full_answer:
         yield TokenEvent(

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -4,6 +4,10 @@ Uses LangChain's create_agent() with a search_docs tool backed by
 retrieve_chunks. The agent autonomously searches, gathers context,
 and decides when to answer.  The agent's own streamed answer is used
 directly — no second LLM call is needed.
+
+Iteration control is handled by ToolCallLimitMiddleware, which gracefully
+stops the agent when limits are reached rather than abruptly cutting off
+execution like recursion_limit.
 """
 
 import logging
@@ -11,6 +15,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from langchain.agents import create_agent
+from langchain.agents.middleware import ToolCallLimitMiddleware
 from langchain.chat_models import init_chat_model
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, AIMessageChunk
@@ -132,6 +137,7 @@ async def _build_agent(
     k: int,
     client: AsyncClient | None,
     accumulated_chunks: list[Document],
+    max_tool_calls: int,
 ) -> CompiledStateGraph:
     """Build the agentic RAG agent with a search tool.
 
@@ -142,6 +148,7 @@ async def _build_agent(
         k: Number of chunks per search.
         client: Optional Supabase client.
         accumulated_chunks: Mutable list for chunk accumulation.
+        max_tool_calls: Maximum number of tool calls allowed per run.
 
     Returns:
         A compiled agent ready for invocation.
@@ -182,10 +189,17 @@ async def _build_agent(
                 "'sanctuary-agentic-rag'. The prompt must contain a system message."
             )
 
+    # Use ToolCallLimitMiddleware for graceful iteration control
+    iteration_limiter = ToolCallLimitMiddleware(
+        run_limit=max_tool_calls,
+        exit_behavior="continue",
+    )
+
     agent = create_agent(
         model=llm,
         tools=[search_tool],
         system_prompt=system_text,
+        middleware=[iteration_limiter],
     )
 
     return agent
@@ -207,6 +221,10 @@ async def execute(
     The agent's own streamed response is forwarded as ``TokenEvent`` objects
     so only a single LLM generation is performed.
 
+    Iteration control is managed by ToolCallLimitMiddleware which gracefully
+    terminates the agent when the limit is reached, allowing it to produce
+    a final answer based on gathered context.
+
     Args:
         query: The user's original question.
         document_id: UUID of the document to search within.
@@ -217,6 +235,7 @@ async def execute(
     Yields:
         ChunksEvent with final documents, then TokenEvent and CitationsEvent.
     """
+    settings = get_settings()
     accumulated: list[Document] = []
 
     agent = await _build_agent(
@@ -226,12 +245,11 @@ async def execute(
         k=k,
         client=client,
         accumulated_chunks=accumulated,
+        max_tool_calls=settings.max_tool_calls,
     )
 
-    settings = get_settings()
     config: RunnableConfig = {
         "configurable": {"thread_id": f"agentic-rag-{document_id}-{user_id}"},
-        "recursion_limit": settings.agentic_rag_max_iterations,
     }
 
     chunks_yielded = False

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -93,7 +93,7 @@ def _make_search_tool(
     """
 
     @tool
-    async def search_docs(query: str) -> str:
+    async def search_docs(query: str = "") -> str:
         """Search the document for relevant information.
 
         Use this tool to find specific facts, concepts, or details
@@ -102,6 +102,12 @@ def _make_search_tool(
         Args:
             query: The specific search query (3-8 words recommended)
         """
+
+        if not query.strip():
+            return (
+                "Please provide a specific search query to find relevant information."
+            )
+
         chunks = await retrieve_chunks(
             query=query,  # ty: ignore[invalid-argument-type]
             document_id=document_id,  # ty: ignore[invalid-argument-type]

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -14,13 +14,14 @@ from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.prompts import ChatPromptTemplate, SystemMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.graph.state import CompiledStateGraph
 from langsmith import traceable
 
 from src.config import get_settings
-from src.prompts.manager import pull_eval_prompt
+from src.prompts.manager import FALLBACK_PROMPTS, pull_eval_prompt
 from src.schemas.chat import (
     ChunksEvent,
     CitationsEvent,
@@ -32,6 +33,34 @@ from src.services.strategies.core import extract_citations, retrieve_chunks
 from supabase import AsyncClient
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_system_text(prompt: ChatPromptTemplate) -> str | None:
+    """Extract the system message template text from a ``ChatPromptTemplate``.
+
+    Iterates over ``prompt.messages`` looking for the first
+    ``SystemMessagePromptTemplate`` and returns its ``.prompt.template``
+    attribute.  Also handles raw ``SystemMessage`` objects (which store
+    text in ``.content``).
+
+    Args:
+        prompt: The prompt template to inspect.
+
+    Returns:
+        The system message text, or ``None`` if no system message is found.
+    """
+    from langchain_core.messages import SystemMessage
+
+    for message in prompt.messages:
+        if isinstance(message, SystemMessagePromptTemplate):
+            template = getattr(message.prompt, "template", None)
+            if template:
+                return template
+        elif isinstance(message, SystemMessage):
+            content = message.content
+            if isinstance(content, str):
+                return content
+    return None
 
 
 def _make_search_tool(
@@ -136,7 +165,22 @@ async def _build_agent(
     )
 
     prompt = await pull_eval_prompt("sanctuary-agentic-rag")
-    system_text = prompt.messages[0].prompt.template  # ty: ignore[unresolved-attribute]
+    system_text = _extract_system_text(prompt)
+
+    if system_text is None:
+        fallback = FALLBACK_PROMPTS.get("sanctuary-agentic-rag")
+        if fallback:
+            logger.warning(
+                "Pulled prompt 'sanctuary-agentic-rag' has no system message. "
+                "Using fallback prompt.",
+            )
+            system_text = _extract_system_text(fallback)
+
+        if system_text is None:
+            raise ValueError(
+                "No system message found in pulled prompt or fallback for "
+                "'sanctuary-agentic-rag'. The prompt must contain a system message."
+            )
 
     agent = create_agent(
         model=llm,

--- a/src/services/strategies/agentic_rag.py
+++ b/src/services/strategies/agentic_rag.py
@@ -1,0 +1,233 @@
+"""Agentic RAG strategy -- LLM agent with search tool.
+
+Uses LangChain's create_agent() with a search_docs tool backed by
+retrieve_chunks. The agent autonomously searches, gathers context,
+and decides when to answer.  The agent's own streamed answer is used
+directly — no second LLM call is needed.
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain.chat_models import init_chat_model
+from langchain_core.documents import Document
+from langchain_core.messages import AIMessageChunk
+from langchain_core.tools import tool
+from langsmith import traceable
+
+from src.config import get_settings
+from src.prompts.manager import pull_eval_prompt
+from src.schemas.chat import (
+    ChunksEvent,
+    CitationsEvent,
+    RetrievedChunk,
+    StreamEvent,
+    TokenEvent,
+)
+from src.services.strategies.core import extract_citations, retrieve_chunks
+from supabase import AsyncClient
+
+logger = logging.getLogger(__name__)
+
+
+def _make_search_tool(
+    *,
+    document_id: str,
+    user_id: str,
+    k: int,
+    client: AsyncClient | None,
+    accumulated_chunks: list[Document],
+):
+    """Create a search tool bound to the current retrieval context.
+
+    The tool accumulates retrieved chunks (deduplicated) into the
+    provided list so they are available after the agent finishes.
+
+    Args:
+        document_id: UUID of the document to search within.
+        user_id: UUID of the user (for authorization).
+        k: Number of chunks per search.
+        client: Optional Supabase client.
+        accumulated_chunks: Mutable list that collected chunks are appended to.
+
+    Returns:
+        A LangChain tool that searches the document's embeddings.
+    """
+
+    @tool
+    async def search_docs(query: str) -> str:
+        """Search the document for relevant information.
+
+        Use this tool to find specific facts, concepts, or details
+        within the document. Be specific with your search queries.
+
+        Args:
+            query: The specific search query (3-8 words recommended)
+        """
+        chunks = await retrieve_chunks(
+            query=query,  # ty: ignore[invalid-argument-type]
+            document_id=document_id,  # ty: ignore[invalid-argument-type]
+            user_id=user_id,  # ty: ignore[invalid-argument-type]
+            k=k,  # ty: ignore[invalid-argument-type]
+            client=client,  # ty: ignore[invalid-argument-type]
+        )
+
+        if not chunks:
+            return "No relevant information found for this query."
+
+        existing_contents = {c.page_content for c in accumulated_chunks}
+        new_chunks = [c for c in chunks if c.page_content not in existing_contents]
+        accumulated_chunks.extend(new_chunks)
+
+        if not new_chunks:
+            return "No additional information found for this query."
+
+        context = "\n\n---\n\n".join(
+            f"[Page {c.metadata.get('page', 'unknown')}]: {c.page_content}"
+            for c in new_chunks
+        )
+        return context
+
+    return search_docs
+
+
+async def _build_agent(
+    *,
+    query: str,
+    document_id: str,
+    user_id: str,
+    k: int,
+    client: AsyncClient | None,
+    accumulated_chunks: list[Document],
+):
+    """Build the agentic RAG agent with a search tool.
+
+    Args:
+        query: The user's question.
+        document_id: UUID of the document to search within.
+        user_id: UUID of the user.
+        k: Number of chunks per search.
+        client: Optional Supabase client.
+        accumulated_chunks: Mutable list for chunk accumulation.
+
+    Returns:
+        A compiled agent ready for invocation.
+    """
+    settings = get_settings()
+    llm = init_chat_model(
+        model=settings.llm_model,
+        model_provider=settings.llm_provider,
+        api_key=settings.openai_api_key.get_secret_value(),
+        base_url=settings.llm_provider_base_url,
+        temperature=0,
+    )
+
+    search_tool = _make_search_tool(
+        document_id=document_id,
+        user_id=user_id,
+        k=k,
+        client=client,
+        accumulated_chunks=accumulated_chunks,
+    )
+
+    prompt = await pull_eval_prompt("sanctuary-agentic-rag")
+    system_text = prompt.messages[0].prompt.template  # ty: ignore[unresolved-attribute]
+
+    agent = create_agent(
+        model=llm,
+        tools=[search_tool],
+        system_prompt=system_text,
+    )
+
+    return agent
+
+
+@traceable(metadata={"rag_strategy": "agentic_rag"})
+async def execute(
+    query: str,
+    document_id: str,
+    user_id: str,
+    k: int = 5,
+    *,
+    client: AsyncClient | None = None,
+) -> AsyncGenerator[StreamEvent, None]:
+    """Run the agentic RAG strategy.
+
+    Builds and streams an LLM agent that autonomously searches the
+    document via a tool, gathers context, and produces a final answer.
+    The agent's own streamed response is forwarded as ``TokenEvent`` objects
+    so only a single LLM generation is performed.
+
+    Args:
+        query: The user's original question.
+        document_id: UUID of the document to search within.
+        user_id: UUID of the user (for authorization).
+        k: Number of chunks to retrieve per search.
+        client: Optional Supabase client to reuse.
+
+    Yields:
+        ChunksEvent with final documents, then TokenEvent and CitationsEvent.
+    """
+    accumulated: list[Document] = []
+
+    agent = await _build_agent(
+        query=query,
+        document_id=document_id,
+        user_id=user_id,
+        k=k,
+        client=client,
+        accumulated_chunks=accumulated,
+    )
+
+    settings = get_settings()
+    config: dict[str, Any] = {
+        "configurable": {"thread_id": f"agentic-rag-{document_id}-{user_id}"},
+        "recursion_limit": settings.agentic_rag_max_iterations,
+    }
+
+    chunks_yielded = False
+    full_answer = ""
+
+    async for msg, metadata in agent.astream(
+        {"messages": [{"role": "user", "content": query}]},
+        config=config,
+        stream_mode="messages",
+    ):
+        if not isinstance(msg, AIMessageChunk):
+            continue
+
+        # Skip tool-call chunks (intermediate reasoning)
+        if msg.tool_call_chunks:
+            continue
+
+        # Yield chunks once, right before the first final-answer token
+        if not chunks_yielded:
+            chunks_yielded = True
+            yield ChunksEvent(
+                chunks=[
+                    RetrievedChunk(
+                        page_content=c.page_content, page=c.metadata.get("page")
+                    )
+                    for c in accumulated
+                ]
+            )
+
+        token = msg.content if isinstance(msg.content, str) else str(msg.content)
+        if token:
+            full_answer += token
+            yield TokenEvent(token=token)
+
+    # If the agent never produced a final answer (e.g. no chunks found)
+    if not chunks_yielded:
+        yield ChunksEvent(chunks=[])
+
+    if not full_answer:
+        yield TokenEvent(
+            token="The document doesn't contain enough information to answer "
+            "this question. Try rephrasing or checking other documents."
+        )
+
+    citations = extract_citations(full_answer, accumulated)
+    yield CitationsEvent(citations=citations)

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -273,7 +273,7 @@ async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system() -> N
 
 @pytest.mark.asyncio
 async def test_execute_yields_chunks_then_tokens_then_citations() -> None:
-    """Execute should yield ChunksEvent, TokenEvents, then CitationsEvent."""
+    """Execute should yield TokenEvents, then ChunksEvent, then CitationsEvent."""
     from src.services.strategies.agentic_rag import execute
 
     mock_chunk = Document(page_content="Answer is 42.", metadata={"page": 5})
@@ -307,12 +307,13 @@ async def test_execute_yields_chunks_then_tokens_then_citations() -> None:
         async for event in execute("What is the answer?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
             events.append(event)
 
-        assert isinstance(events[0], ChunksEvent)
-        assert len(events[0].chunks) == 1
-        assert events[0].chunks[0].page_content == "Answer is 42."
-        assert events[0].chunks[0].page == 5
+        # ChunksEvent is yielded after all tokens, before CitationsEvent
+        assert isinstance(events[-2], ChunksEvent)
+        assert len(events[-2].chunks) == 1
+        assert events[-2].chunks[0].page_content == "Answer is 42."
+        assert events[-2].chunks[0].page == 5
 
-        for e in events[1:-1]:
+        for e in events[:-2]:
             assert isinstance(e, TokenEvent)
 
         assert isinstance(events[-1], CitationsEvent)

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -1,11 +1,13 @@
 """Tests for the agentic RAG strategy."""
 
+from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessageChunk
+from langgraph.graph.state import CompiledStateGraph
 
 from src.schemas.chat import ChunksEvent, CitationsEvent, TokenEvent
 
@@ -13,7 +15,7 @@ from src.schemas.chat import ChunksEvent, CitationsEvent, TokenEvent
 
 
 @pytest.mark.asyncio
-async def test_search_tool_returns_chunk_content():
+async def test_search_tool_returns_chunk_content() -> None:
     """The search_docs tool should return formatted chunk content."""
     from src.services.strategies.agentic_rag import _make_search_tool
 
@@ -43,7 +45,7 @@ async def test_search_tool_returns_chunk_content():
 
 
 @pytest.mark.asyncio
-async def test_search_tool_accumulates_new_chunks():
+async def test_search_tool_accumulates_new_chunks() -> None:
     """The search_docs tool should deduplicate and accumulate new chunks."""
     from src.services.strategies.agentic_rag import _make_search_tool
 
@@ -69,7 +71,7 @@ async def test_search_tool_accumulates_new_chunks():
 
 
 @pytest.mark.asyncio
-async def test_search_tool_returns_no_results_message():
+async def test_search_tool_returns_no_results_message() -> None:
     """The search_docs tool should return a message when no chunks found."""
     from src.services.strategies.agentic_rag import _make_search_tool
 
@@ -93,7 +95,7 @@ async def test_search_tool_returns_no_results_message():
 
 
 @pytest.mark.asyncio
-async def test_search_tool_returns_no_additional_message():
+async def test_search_tool_returns_no_additional_message() -> None:
     """The search_docs tool should return message when all chunks are duplicates."""
     from src.services.strategies.agentic_rag import _make_search_tool
 
@@ -189,7 +191,7 @@ def test_extract_system_text_handles_raw_system_message():
 
 
 @pytest.mark.asyncio
-async def test_build_agent_returns_agent():
+async def test_build_agent_returns_agent() -> None:
     """_build_agent should return an agent with astream."""
     from src.services.strategies.agentic_rag import _build_agent
 
@@ -223,7 +225,7 @@ async def test_build_agent_returns_agent():
 
 
 @pytest.mark.asyncio
-async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system():
+async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system() -> None:
     """_build_agent should fall back to hardcoded prompt if pulled has no system message."""
     from langchain_core.prompts import ChatPromptTemplate
 
@@ -268,16 +270,26 @@ async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system():
 
 
 @pytest.mark.asyncio
-async def test_execute_yields_chunks_then_tokens_then_citations():
+async def test_execute_yields_chunks_then_tokens_then_citations() -> None:
     """Execute should yield ChunksEvent, TokenEvents, then CitationsEvent."""
     from src.services.strategies.agentic_rag import execute
 
     mock_chunk = Document(page_content="Answer is 42.", metadata={"page": 5})
 
     async def fake_build_agent(
-        *, query, document_id, user_id, k, client, accumulated_chunks
-    ):
-        async def fake_astream(input_dict, config=None, stream_mode=None):
+        *,
+        query: str,
+        document_id: str,
+        user_id: str,
+        k: int,
+        client: Any,
+        accumulated_chunks: list[Document],
+    ) -> CompiledStateGraph:
+        async def fake_astream(
+            input_dict: dict[str, Any],
+            config: Any = None,
+            stream_mode: Any = None,
+        ) -> AsyncGenerator[tuple[AIMessageChunk, dict[str, str]], None]:
             accumulated_chunks.append(mock_chunk)
             for token in ["The ", "answer ", "is ", "42. [p. 5]"]:
                 yield AIMessageChunk(content=token), {"langgraph_node": "agent"}
@@ -305,14 +317,24 @@ async def test_execute_yields_chunks_then_tokens_then_citations():
 
 
 @pytest.mark.asyncio
-async def test_execute_yields_empty_chunks_when_no_results():
+async def test_execute_yields_empty_chunks_when_no_results() -> None:
     """Execute should yield empty ChunksEvent when agent finds nothing."""
     from src.services.strategies.agentic_rag import execute
 
     async def fake_build_agent(
-        *, query, document_id, user_id, k, client, accumulated_chunks
-    ):
-        async def fake_astream(input_dict, config=None, stream_mode=None):
+        *,
+        query: str,
+        document_id: str,
+        user_id: str,
+        k: int,
+        client: Any,
+        accumulated_chunks: list[Document],
+    ) -> CompiledStateGraph:
+        async def fake_astream(
+            input_dict: dict[str, Any],
+            config: Any = None,
+            stream_mode: Any = None,
+        ) -> Any:
             return
             yield  # noqa: F841 — makes this an async generator
 
@@ -333,16 +355,26 @@ async def test_execute_yields_empty_chunks_when_no_results():
 
 
 @pytest.mark.asyncio
-async def test_execute_passes_recursion_limit_to_agent():
+async def test_execute_passes_recursion_limit_to_agent() -> None:
     """Execute should pass recursion_limit from settings."""
     from src.services.strategies.agentic_rag import execute
 
     captured_config: dict[str, Any] = {}
 
     async def fake_build_agent(
-        *, query, document_id, user_id, k, client, accumulated_chunks
-    ):
-        async def fake_astream(input_dict, config=None, stream_mode=None):
+        *,
+        query: str,
+        document_id: str,
+        user_id: str,
+        k: int,
+        client: Any,
+        accumulated_chunks: list[Document],
+    ) -> CompiledStateGraph:
+        async def fake_astream(
+            input_dict: dict[str, Any],
+            config: Any = None,
+            stream_mode: Any = None,
+        ) -> Any:
             captured_config["config"] = config
             return
             yield  # noqa: F841 — makes this an async generator
@@ -365,16 +397,26 @@ async def test_execute_passes_recursion_limit_to_agent():
 
 
 @pytest.mark.asyncio
-async def test_execute_skips_tool_call_chunks():
+async def test_execute_skips_tool_call_chunks() -> None:
     """Execute should skip AIMessageChunks that contain tool_call_chunks."""
     from src.services.strategies.agentic_rag import execute
 
     mock_chunk = Document(page_content="Some info.", metadata={"page": 1})
 
     async def fake_build_agent(
-        *, query, document_id, user_id, k, client, accumulated_chunks
-    ):
-        async def fake_astream(input_dict, config=None, stream_mode=None):
+        *,
+        query: str,
+        document_id: str,
+        user_id: str,
+        k: int,
+        client: Any,
+        accumulated_chunks: list[Document],
+    ) -> CompiledStateGraph:
+        async def fake_astream(
+            input_dict: dict[str, Any],
+            config: Any = None,
+            stream_mode: Any = None,
+        ) -> AsyncGenerator[tuple[AIMessageChunk, dict[str, str]], None]:
             accumulated_chunks.append(mock_chunk)
             tool_msg = AIMessageChunk(content="")
             tool_msg.tool_call_chunks = [{"name": "search_docs", "args": "{}"}]  # ty:ignore[invalid-assignment]

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -71,6 +71,38 @@ async def test_search_tool_accumulates_new_chunks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_tool_returns_empty_query_message() -> None:
+    """The search_docs tool should return a prompt when query is empty or whitespace."""
+    from src.services.strategies.agentic_rag import _make_search_tool
+
+    accumulated: list[Document] = []
+
+    search_tool = _make_search_tool(
+        document_id="doc-123",
+        user_id="user-456",
+        k=5,
+        client=None,
+        accumulated_chunks=accumulated,
+    )
+
+    # Test with empty string
+    result = await search_tool.ainvoke({"query": ""})
+    assert "Please provide a specific search query" in result
+
+    # Test with whitespace-only
+    result = await search_tool.ainvoke({"query": "   "})
+    assert "Please provide a specific search query" in result
+
+    # Ensure retrieve_chunks was never called for empty queries
+    with patch(
+        "src.services.strategies.agentic_rag.retrieve_chunks",
+        new_callable=AsyncMock,
+    ) as mock_retrieve:
+        await search_tool.ainvoke({"query": ""})
+        mock_retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_search_tool_returns_no_results_message() -> None:
     """The search_docs tool should return a message when no chunks found."""
     from src.services.strategies.agentic_rag import _make_search_tool

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -117,6 +117,74 @@ async def test_search_tool_returns_no_additional_message():
     assert "No additional information found" in result
 
 
+# --- _extract_system_text tests ---
+
+
+def test_extract_system_text_returns_template_text():
+    """_extract_system_text should return the system message template."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from src.services.strategies.agentic_rag import _extract_system_text
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a helpful assistant."),
+            ("human", "{query}"),
+        ]
+    )
+    result = _extract_system_text(prompt)
+    assert result == "You are a helpful assistant."
+
+
+def test_extract_system_text_finds_system_at_non_zero_position():
+    """_extract_system_text should find the system message even if not first."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from src.services.strategies.agentic_rag import _extract_system_text
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("human", "Hello"),
+            ("system", "You are a research assistant."),
+            ("human", "{query}"),
+        ]
+    )
+    result = _extract_system_text(prompt)
+    assert result == "You are a research assistant."
+
+
+def test_extract_system_text_returns_none_when_no_system_message():
+    """_extract_system_text should return None if no system message exists."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from src.services.strategies.agentic_rag import _extract_system_text
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("human", "{query}"),
+        ]
+    )
+    result = _extract_system_text(prompt)
+    assert result is None
+
+
+def test_extract_system_text_handles_raw_system_message():
+    """_extract_system_text should handle raw SystemMessage objects."""
+    from langchain_core.messages import SystemMessage
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from src.services.strategies.agentic_rag import _extract_system_text
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            SystemMessage(content="You are an assistant."),
+            ("human", "{query}"),
+        ]
+    )
+    result = _extract_system_text(prompt)
+    assert result == "You are an assistant."
+
+
 # --- _build_agent tests ---
 
 
@@ -150,6 +218,48 @@ async def test_build_agent_returns_agent():
                 accumulated_chunks=accumulated,
             )
 
+    assert agent is not None
+    assert hasattr(agent, "astream")
+
+
+@pytest.mark.asyncio
+async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system():
+    """_build_agent should fall back to hardcoded prompt if pulled has no system message."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from src.services.strategies.agentic_rag import _build_agent
+
+    accumulated: list[Document] = []
+
+    # A pulled prompt with no system message (only human)
+    broken_prompt = ChatPromptTemplate.from_messages(
+        [
+            ("human", "{query}"),
+        ]
+    )
+
+    with patch("src.services.strategies.agentic_rag.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(
+            llm_model="gpt-4o-mini",
+            llm_provider="openai",
+            openai_api_key=MagicMock(get_secret_value=lambda: "test-key"),
+            llm_provider_base_url="https://api.openai.com/v1",
+        )
+        with patch(
+            "src.services.strategies.agentic_rag.pull_eval_prompt",
+            new_callable=AsyncMock,
+            return_value=broken_prompt,
+        ):
+            agent = await _build_agent(
+                query="What is the answer?",
+                document_id="doc-123",
+                user_id="user-456",
+                k=5,
+                client=None,
+                accumulated_chunks=accumulated,
+            )
+
+    # Agent should still be built using the fallback prompt
     assert agent is not None
     assert hasattr(agent, "astream")
 

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -1,0 +1,286 @@
+"""Tests for the agentic RAG strategy."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.messages import AIMessageChunk
+
+from src.schemas.chat import ChunksEvent, CitationsEvent, TokenEvent
+
+# --- _make_search_tool tests ---
+
+
+@pytest.mark.asyncio
+async def test_search_tool_returns_chunk_content():
+    """The search_docs tool should return formatted chunk content."""
+    from src.services.strategies.agentic_rag import _make_search_tool
+
+    mock_chunks = [
+        Document(page_content="The sky is blue.", metadata={"page": 1}),
+        Document(page_content="Clouds are white.", metadata={"page": 1}),
+    ]
+
+    accumulated: list[Document] = []
+
+    with patch(
+        "src.services.strategies.agentic_rag.retrieve_chunks",
+        new_callable=AsyncMock,
+        return_value=mock_chunks,
+    ):
+        search_tool = _make_search_tool(
+            document_id="doc-123",
+            user_id="user-456",
+            k=5,
+            client=None,
+            accumulated_chunks=accumulated,
+        )
+        result = await search_tool.ainvoke({"query": "sky color"})
+
+    assert "The sky is blue." in result
+    assert "Clouds are white." in result
+
+
+@pytest.mark.asyncio
+async def test_search_tool_accumulates_new_chunks():
+    """The search_docs tool should deduplicate and accumulate new chunks."""
+    from src.services.strategies.agentic_rag import _make_search_tool
+
+    existing = Document(page_content="Existing content.", metadata={"page": 1})
+    new_chunk = Document(page_content="New content.", metadata={"page": 2})
+    accumulated: list[Document] = [existing]
+
+    with patch(
+        "src.services.strategies.agentic_rag.retrieve_chunks",
+        new_callable=AsyncMock,
+        return_value=[existing, new_chunk],
+    ):
+        search_tool = _make_search_tool(
+            document_id="doc-123",
+            user_id="user-456",
+            k=5,
+            client=None,
+            accumulated_chunks=accumulated,
+        )
+        await search_tool.ainvoke({"query": "test query"})
+
+    assert len(accumulated) == 2
+
+
+@pytest.mark.asyncio
+async def test_search_tool_returns_no_results_message():
+    """The search_docs tool should return a message when no chunks found."""
+    from src.services.strategies.agentic_rag import _make_search_tool
+
+    accumulated: list[Document] = []
+
+    with patch(
+        "src.services.strategies.agentic_rag.retrieve_chunks",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        search_tool = _make_search_tool(
+            document_id="doc-123",
+            user_id="user-456",
+            k=5,
+            client=None,
+            accumulated_chunks=accumulated,
+        )
+        result = await search_tool.ainvoke({"query": "nothing found"})
+
+    assert "No relevant information found" in result
+
+
+@pytest.mark.asyncio
+async def test_search_tool_returns_no_additional_message():
+    """The search_docs tool should return message when all chunks are duplicates."""
+    from src.services.strategies.agentic_rag import _make_search_tool
+
+    existing = Document(page_content="Already have this.", metadata={"page": 1})
+    accumulated: list[Document] = [existing]
+
+    with patch(
+        "src.services.strategies.agentic_rag.retrieve_chunks",
+        new_callable=AsyncMock,
+        return_value=[existing],
+    ):
+        search_tool = _make_search_tool(
+            document_id="doc-123",
+            user_id="user-456",
+            k=5,
+            client=None,
+            accumulated_chunks=accumulated,
+        )
+        result = await search_tool.ainvoke({"query": "duplicate query"})
+
+    assert "No additional information found" in result
+
+
+# --- _build_agent tests ---
+
+
+@pytest.mark.asyncio
+async def test_build_agent_returns_agent():
+    """_build_agent should return an agent with astream."""
+    from src.services.strategies.agentic_rag import _build_agent
+
+    accumulated: list[Document] = []
+
+    with patch("src.services.strategies.agentic_rag.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(
+            llm_model="gpt-4o-mini",
+            llm_provider="openai",
+            openai_api_key=MagicMock(get_secret_value=lambda: "test-key"),
+            llm_provider_base_url="https://api.openai.com/v1",
+        )
+        with patch(
+            "src.services.strategies.agentic_rag.pull_eval_prompt",
+            new_callable=AsyncMock,
+        ) as mock_prompt:
+            mock_sys = MagicMock()
+            mock_sys.prompt.template = "You are a research assistant."
+            mock_prompt.return_value = MagicMock(messages=[mock_sys])
+            agent = await _build_agent(
+                query="What is the answer?",
+                document_id="doc-123",
+                user_id="user-456",
+                k=5,
+                client=None,
+                accumulated_chunks=accumulated,
+            )
+
+    assert agent is not None
+    assert hasattr(agent, "astream")
+
+
+# --- execute tests ---
+
+
+@pytest.mark.asyncio
+async def test_execute_yields_chunks_then_tokens_then_citations():
+    """Execute should yield ChunksEvent, TokenEvents, then CitationsEvent."""
+    from src.services.strategies.agentic_rag import execute
+
+    mock_chunk = Document(page_content="Answer is 42.", metadata={"page": 5})
+
+    async def fake_build_agent(
+        *, query, document_id, user_id, k, client, accumulated_chunks
+    ):
+        async def fake_astream(input_dict, config=None, stream_mode=None):
+            accumulated_chunks.append(mock_chunk)
+            for token in ["The ", "answer ", "is ", "42. [p. 5]"]:
+                yield AIMessageChunk(content=token), {"langgraph_node": "agent"}
+
+        return MagicMock(astream=fake_astream)
+
+    with patch(
+        "src.services.strategies.agentic_rag._build_agent",
+        side_effect=fake_build_agent,
+    ):
+        events = []
+        async for event in execute("What is the answer?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
+            events.append(event)
+
+        assert isinstance(events[0], ChunksEvent)
+        assert len(events[0].chunks) == 1
+        assert events[0].chunks[0].page_content == "Answer is 42."
+        assert events[0].chunks[0].page == 5
+
+        for e in events[1:-1]:
+            assert isinstance(e, TokenEvent)
+
+        assert isinstance(events[-1], CitationsEvent)
+        assert events[-1].citations[0].page == 5
+
+
+@pytest.mark.asyncio
+async def test_execute_yields_empty_chunks_when_no_results():
+    """Execute should yield empty ChunksEvent when agent finds nothing."""
+    from src.services.strategies.agentic_rag import execute
+
+    async def fake_build_agent(
+        *, query, document_id, user_id, k, client, accumulated_chunks
+    ):
+        async def fake_astream(input_dict, config=None, stream_mode=None):
+            return
+            yield  # noqa: F841 — makes this an async generator
+
+        return MagicMock(astream=fake_astream)
+
+    with patch(
+        "src.services.strategies.agentic_rag._build_agent",
+        side_effect=fake_build_agent,
+    ):
+        events = []
+        async for event in execute("Unknown topic?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
+            events.append(event)
+
+        assert isinstance(events[0], ChunksEvent)
+        assert events[0].chunks == []
+        assert isinstance(events[1], TokenEvent)
+        assert isinstance(events[2], CitationsEvent)
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_recursion_limit_to_agent():
+    """Execute should pass recursion_limit from settings."""
+    from src.services.strategies.agentic_rag import execute
+
+    captured_config: dict[str, Any] = {}
+
+    async def fake_build_agent(
+        *, query, document_id, user_id, k, client, accumulated_chunks
+    ):
+        async def fake_astream(input_dict, config=None, stream_mode=None):
+            captured_config["config"] = config
+            return
+            yield  # noqa: F841 — makes this an async generator
+
+        return MagicMock(astream=fake_astream)
+
+    with (
+        patch(
+            "src.services.strategies.agentic_rag._build_agent",
+            side_effect=fake_build_agent,
+        ),
+        patch("src.services.strategies.agentic_rag.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value = MagicMock(agentic_rag_max_iterations=15)
+
+        async for _ in execute("test?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
+            pass
+
+    assert captured_config["config"]["recursion_limit"] == 15
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_tool_call_chunks():
+    """Execute should skip AIMessageChunks that contain tool_call_chunks."""
+    from src.services.strategies.agentic_rag import execute
+
+    mock_chunk = Document(page_content="Some info.", metadata={"page": 1})
+
+    async def fake_build_agent(
+        *, query, document_id, user_id, k, client, accumulated_chunks
+    ):
+        async def fake_astream(input_dict, config=None, stream_mode=None):
+            accumulated_chunks.append(mock_chunk)
+            tool_msg = AIMessageChunk(content="")
+            tool_msg.tool_call_chunks = [{"name": "search_docs", "args": "{}"}]  # ty:ignore[invalid-assignment]
+            yield tool_msg, {"langgraph_node": "agent"}
+            yield AIMessageChunk(content="Final answer."), {"langgraph_node": "agent"}
+
+        return MagicMock(astream=fake_astream)
+
+    with patch(
+        "src.services.strategies.agentic_rag._build_agent",
+        side_effect=fake_build_agent,
+    ):
+        events = []
+        async for event in execute("test?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
+            events.append(event)
+
+        token_events = [e for e in events if isinstance(e, TokenEvent)]
+        assert len(token_events) == 1
+        assert token_events[0].token == "Final answer."

--- a/src/services/strategies/agentic_rag_test.py
+++ b/src/services/strategies/agentic_rag_test.py
@@ -191,8 +191,8 @@ def test_extract_system_text_handles_raw_system_message():
 
 
 @pytest.mark.asyncio
-async def test_build_agent_returns_agent() -> None:
-    """_build_agent should return an agent with astream."""
+async def test_build_agent_returns_configured_agent() -> None:
+    """_build_agent should return an agent with middleware for iteration control."""
     from src.services.strategies.agentic_rag import _build_agent
 
     accumulated: list[Document] = []
@@ -218,6 +218,7 @@ async def test_build_agent_returns_agent() -> None:
                 k=5,
                 client=None,
                 accumulated_chunks=accumulated,
+                max_tool_calls=10,
             )
 
     assert agent is not None
@@ -259,6 +260,7 @@ async def test_build_agent_uses_fallback_when_pulled_prompt_has_no_system() -> N
                 k=5,
                 client=None,
                 accumulated_chunks=accumulated,
+                max_tool_calls=10,
             )
 
     # Agent should still be built using the fallback prompt
@@ -284,6 +286,7 @@ async def test_execute_yields_chunks_then_tokens_then_citations() -> None:
         k: int,
         client: Any,
         accumulated_chunks: list[Document],
+        max_tool_calls: int,
     ) -> CompiledStateGraph:
         async def fake_astream(
             input_dict: dict[str, Any],
@@ -329,6 +332,7 @@ async def test_execute_yields_empty_chunks_when_no_results() -> None:
         k: int,
         client: Any,
         accumulated_chunks: list[Document],
+        max_tool_calls: int,
     ) -> CompiledStateGraph:
         async def fake_astream(
             input_dict: dict[str, Any],
@@ -355,11 +359,11 @@ async def test_execute_yields_empty_chunks_when_no_results() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_passes_recursion_limit_to_agent() -> None:
-    """Execute should pass recursion_limit from settings."""
+async def test_execute_passes_max_tool_calls_to_build_agent() -> None:
+    """Execute should pass max_tool_calls from settings to _build_agent."""
     from src.services.strategies.agentic_rag import execute
 
-    captured_config: dict[str, Any] = {}
+    captured_max_tool_calls: int | None = None
 
     async def fake_build_agent(
         *,
@@ -369,13 +373,16 @@ async def test_execute_passes_recursion_limit_to_agent() -> None:
         k: int,
         client: Any,
         accumulated_chunks: list[Document],
+        max_tool_calls: int,
     ) -> CompiledStateGraph:
+        nonlocal captured_max_tool_calls
+        captured_max_tool_calls = max_tool_calls
+
         async def fake_astream(
             input_dict: dict[str, Any],
             config: Any = None,
             stream_mode: Any = None,
         ) -> Any:
-            captured_config["config"] = config
             return
             yield  # noqa: F841 — makes this an async generator
 
@@ -388,12 +395,15 @@ async def test_execute_passes_recursion_limit_to_agent() -> None:
         ),
         patch("src.services.strategies.agentic_rag.get_settings") as mock_settings,
     ):
-        mock_settings.return_value = MagicMock(agentic_rag_max_iterations=15)
+        # Return a real integer for max_tool_calls
+        mock_settings_instance = MagicMock()
+        mock_settings_instance.max_tool_calls = 15
+        mock_settings.return_value = mock_settings_instance
 
         async for _ in execute("test?", "doc-123", "user-456"):  # ty: ignore[invalid-argument-type]
             pass
 
-    assert captured_config["config"]["recursion_limit"] == 15
+    assert captured_max_tool_calls == 15
 
 
 @pytest.mark.asyncio
@@ -411,6 +421,7 @@ async def test_execute_skips_tool_call_chunks() -> None:
         k: int,
         client: Any,
         accumulated_chunks: list[Document],
+        max_tool_calls: int,
     ) -> CompiledStateGraph:
         async def fake_astream(
             input_dict: dict[str, Any],

--- a/src/services/strategies/registry.py
+++ b/src/services/strategies/registry.py
@@ -23,6 +23,7 @@ def get_strategy(name: str) -> StrategyFn:
     Raises:
         ValueError: If the strategy name is not registered.
     """
+    from src.services.strategies.agentic_rag import execute as agentic_rag_execute
     from src.services.strategies.multi_query import execute as multi_query_execute
     from src.services.strategies.naive_rag import execute as naive_rag_execute
     from src.services.strategies.query_rewrite import execute as query_rewrite_execute
@@ -35,6 +36,7 @@ def get_strategy(name: str) -> StrategyFn:
         "query_rewrite": query_rewrite_execute,
         "multi_query": multi_query_execute,
         "self_correcting": self_correcting_execute,
+        "agentic_rag": agentic_rag_execute,
     }
 
     if name not in registry:


### PR DESCRIPTION
Fix #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "agentic RAG" strategy for agent-based document retrieval with streaming answers and citation support.
  * Strategy is now discoverable/usable via the strategy registry.
  * Fallback prompt for agentic RAG added to ensure consistent agent behavior.

* **Configuration**
  * New max_tool_calls setting to limit agent tool invocations.

* **Tests**
  * Added comprehensive tests covering agentic RAG behavior, streaming output, and registration.

* **Documentation**
  * Updated example environment docs to include the new RAG option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->